### PR TITLE
Issue #127 Using timer for time based idle checks

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -21,6 +21,9 @@ type Configuration interface {
 	// GetMaxRetries returns the maximum number of retries to idle resp. un-idle the Jenkins service.
 	GetMaxRetries() int
 
+	// GetMaxRetriesQuietInterval returns the number of minutes no retry occurs after the maximum retry count is reached.
+	GetMaxRetriesQuietInterval() int
+
 	// GetCheckInterval returns the number of minutes after which a regular idle check occurs.
 	GetCheckInterval() int
 

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	defaultIdleAfter     = 45
-	defaultMaxRetries    = 5
-	defaultCheckInterval = 15
+	defaultIdleAfter               = 45
+	defaultMaxRetries              = 3
+	defaultMaxRetriesQuietInterval = 30
+	defaultCheckInterval           = 15
 )
 
 var (
@@ -35,6 +36,7 @@ func init() {
 	// timeouts and retry counts
 	settings["GetIdleAfter"] = Setting{"JC_IDLE_AFTER", strconv.Itoa(defaultIdleAfter), []func(interface{}, string) error{util.IsInt}}
 	settings["GetMaxRetries"] = Setting{"JC_MAX_RETRIES", strconv.Itoa(defaultMaxRetries), []func(interface{}, string) error{util.IsInt}}
+	settings["GetMaxRetriesQuietInterval"] = Setting{"JC_MAX_RETRIES_QUIET_INTERVAL", strconv.Itoa(defaultMaxRetriesQuietInterval), []func(interface{}, string) error{util.IsInt}}
 	settings["GetCheckInterval"] = Setting{"JC_CHECK_INTERVAL", strconv.Itoa(defaultCheckInterval), []func(interface{}, string) error{util.IsInt}}
 
 	// debug
@@ -69,6 +71,15 @@ func (c *EnvConfig) GetProxyURL() string {
 
 // GetIdleAfter returns the number of minutes before Jenkins is idled as set via default, config file, or environment variable.
 func (c *EnvConfig) GetIdleAfter() int {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := c.getConfigValueFromEnv(util.NameOfFunction(callPtr))
+
+	i, _ := strconv.Atoi(value)
+	return i
+}
+
+// GetMaxRetriesQuietInterval returns the number of minutes no retry occurs after the maximum retry count is reached.
+func (c *EnvConfig) GetMaxRetriesQuietInterval() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := c.getConfigValueFromEnv(util.NameOfFunction(callPtr))
 

--- a/internal/openshift/controller.go
+++ b/internal/openshift/controller.go
@@ -189,7 +189,7 @@ func (c *controllerImpl) createIfNotExist(ns string) (bool, error) {
 	newUser := model.NewUser(ti.Data[0].ID, ns)
 	userIdler := idler.NewUserIdler(newUser, c.openShiftAPIURL, c.openShiftBearerToken, c.config, c.features)
 	c.userIdlers.Store(ns, userIdler)
-	userIdler.Run(c.ctx, c.wg, c.cancel, time.Duration(c.config.GetCheckInterval())*time.Minute)
+	userIdler.Run(c.ctx, c.wg, c.cancel, time.Duration(c.config.GetCheckInterval())*time.Minute, time.Duration(c.config.GetMaxRetriesQuietInterval())*time.Minute)
 	return true, nil
 }
 

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -7,18 +7,19 @@ import (
 // Config a mock implementation of the configuration.Configuration interface.
 // It can be used in tests where any field can be explicitly set to return the needed value.
 type Config struct {
-	ProxyURL             string
-	TenantURL            string
-	ToggleURL            string
-	IdleAfter            int
-	MaxRetries           int
-	CheckInterval        int
-	Debug                bool
-	FixedUuids           []string
-	AuthURL              string
-	ServiceAccountID     string
-	ServiceAccountSecret string
-	AuthTokenKey         string
+	ProxyURL              string
+	TenantURL             string
+	ToggleURL             string
+	IdleAfter             int
+	MaxRetries            int
+	MaxRetriesQuietPeriod int
+	CheckInterval         int
+	Debug                 bool
+	FixedUuids            []string
+	AuthURL               string
+	ServiceAccountID      string
+	ServiceAccountSecret  string
+	AuthTokenKey          string
 }
 
 // GetProxyURL returns the Jenkins Proxy API URL.
@@ -49,6 +50,11 @@ func (c *Config) GetIdleAfter() int {
 // GetMaxRetries returns the maximum number of retries to idle resp. un-idle the Jenkins service.
 func (c *Config) GetMaxRetries() int {
 	return c.MaxRetries
+}
+
+// GetMaxRetriesQuietInterval returns the number of minutes no retry occurs after the maximum retry count is reached.
+func (c *Config) GetMaxRetriesQuietInterval() int {
+	return c.MaxRetriesQuietPeriod
 }
 
 // GetCheckInterval returns the number of minutes after which a regular idle check occurs.

--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -39,6 +39,11 @@ objects:
               configMapKeyRef:
                 name: jenkins-idler
                 key: max.retries
+          - name: JC_MAX_RETRIES_QUIET_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                name: jenkins-idler
+                key: max.retries.quiet.interval
           - name: JC_CHECK_INTERVAL
             valueFrom:
               configMapKeyRef:

--- a/openshift/jenkins-idler.configmap.yaml
+++ b/openshift/jenkins-idler.configmap.yaml
@@ -6,6 +6,7 @@ type: Opaque
 data:
   idle.after: "45"
   check.interval: "15"
-  max.retries: "5"
+  max.retries: "3"
+  max.retries.quiet.interval: "30"
   jenkins.proxy.url: "http://jenkins-proxy:9091"
   toggles.api.url: "http://f8toggles"


### PR DESCRIPTION
- Now a timer is used for time-based idle checks. If an OpenShift event comes in, the timer is reset
  Time-based idle checks only occur if there is no event for JC_CHECK_INTERVAL minutes
- Introduced a dedicated JC_MAX_RETRIES_QUIET_INTERVAL which controls how long no ide/un-idle request
  occurs was the max retry count is reached. This timer gets reset via a ticker

Addresses issue #127