### PR TITLE
Issue 152 Accessing Idle API endpoint returns errors without context

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/testutils/mock"
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+)
+
+type JSError struct {
+	Error string
+}
+
+type ReqFuncType func(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
+
+func Test_success(t *testing.T) {
+	mockidle := idler{
+		openShiftClient: &mock.OpenShiftClient{},
+		clusterView:     &mock.ClusterView{},
+	}
+	functions := []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle}
+
+	for _, function := range functions {
+		reader, _ := http.NewRequest("GET", "/", nil)
+		q := reader.URL.Query()
+		q.Add(OpenShiftAPIParam, "http://localhost")
+		reader.URL.RawQuery = q.Encode()
+
+		writer := &mock.ResponseWriter{}
+		function(writer, reader, nil)
+
+		require.Equal(t, http.StatusOK, writer.WriterStatus, fmt.Sprintf("Bad Error Code: %d", writer.WriterStatus))
+	}
+}
+
+func Test_fail(t *testing.T) {
+	mockidle := idler{
+		openShiftClient: &mock.OpenShiftClient{},
+		clusterView:     &mock.ClusterView{},
+	}
+	functions := []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle}
+	for _, function := range functions {
+		reader, _ := http.NewRequest("GET", "/", nil)
+		writer := &mock.ResponseWriter{}
+		function(writer, reader, nil)
+
+		require.Equal(t, http.StatusBadRequest, writer.WriterStatus, fmt.Sprintf("Bad Error Code: %d", writer.WriterStatus))
+
+		jserror := &JSError{}
+		_ = json.Unmarshal(writer.Buffer.Bytes(), &jserror)
+		require.Equal(t, "OpenShift API URL needs to be specified", jserror.Error, fmt.Sprintf("Unexpected error output: %s", jserror.Error))
+	}
+
+	idleError := "Error when Idling"
+	mockidle = idler{
+		openShiftClient: &mock.OpenShiftClient{
+			IdleError: idleError,
+		},
+		clusterView: &mock.ClusterView{},
+	}
+	functions = []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle}
+	for _, function := range functions {
+		req, _ := http.NewRequest("GET", "/", nil)
+		query := req.URL.Query()
+		query.Add(OpenShiftAPIParam, "http://localhost")
+		req.URL.RawQuery = query.Encode()
+
+		writer := &mock.ResponseWriter{}
+		function(writer, req, nil)
+
+		jserror := &JSError{}
+		_ = json.Unmarshal(writer.Buffer.Bytes(), &jserror)
+		require.Equal(t, idleError, jserror.Error, fmt.Sprintf("Unexpected error output: %s", jserror.Error))
+	}
+}

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -126,6 +126,9 @@ func (o openShift) Idle(apiURL string, bearerToken string, namespace string, ser
 		return
 	}
 	b, err = o.patch(req)
+	if err != nil {
+		return
+	}
 	ndc := &model.DeploymentConfig{}
 	err = json.Unmarshal(b, ndc)
 	if err != nil {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -12,45 +11,23 @@ import (
 	"time"
 
 	"encoding/json"
+	"net/http/httptest"
+
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/api"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/cluster"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/openshift"
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/testutils/mock"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/util"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
-	"net/http/httptest"
 )
 
 const (
 	testPortBase = 48080
 )
-
-type mockResponseWriter struct {
-	buffer bytes.Buffer
-}
-
-func (m *mockResponseWriter) Header() (h http.Header) {
-	return http.Header{}
-}
-
-func (m *mockResponseWriter) Write(p []byte) (n int, err error) {
-	m.buffer.Write(p)
-	return len(p), nil
-}
-
-func (m *mockResponseWriter) WriteString(s string) (n int, err error) {
-	m.buffer.WriteString(s)
-	return len(s), nil
-}
-
-func (m *mockResponseWriter) WriteHeader(int) {}
-
-func (m *mockResponseWriter) GetBody() string {
-	return m.buffer.String()
-}
 
 type mockIdlerAPI struct {
 }
@@ -103,7 +80,7 @@ func Test_all_routes_are_setup(t *testing.T) {
 	}
 
 	for _, testRoute := range routes {
-		w := new(mockResponseWriter)
+		w := new(mock.ResponseWriter)
 
 		req, _ := http.NewRequest("GET", testRoute.route, nil)
 		router.ServeHTTP(w, req)

--- a/internal/testutils/mock/mock_cluster_view.go
+++ b/internal/testutils/mock/mock_cluster_view.go
@@ -1,0 +1,26 @@
+package mock
+
+import "github.com/fabric8-services/fabric8-jenkins-idler/internal/cluster"
+
+// ClusterView provides a view over the current cluster topology.
+// This is the mock interface
+type ClusterView struct{}
+
+// GetClusters get cluster view
+func (m *ClusterView) GetClusters() (r []cluster.Cluster) {
+	return
+}
+
+// GetDNSView get dns view
+func (m *ClusterView) GetDNSView() (r []cluster.DNSView) {
+	return
+}
+
+// GetToken get token of cluster
+func (m *ClusterView) GetToken(openShiftAPIURL string) (string, bool) {
+	return "", true
+}
+
+func (m *ClusterView) String() string {
+	return ""
+}

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"fmt"
+
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 )
 
@@ -10,12 +12,16 @@ type OpenShiftClient struct {
 	IdleState       int
 	IdleCallCount   int
 	UnIdleCallCount int
+	IdleError       string
 }
 
 // Idle mocks Idle method of client.OpenShiftClient.
 // It increases IdleCallCount by 1.
 func (c *OpenShiftClient) Idle(apiURL string, bearerToken string, namespace string, service string) error {
 	c.IdleCallCount++
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
 	return nil
 }
 
@@ -23,28 +29,43 @@ func (c *OpenShiftClient) Idle(apiURL string, bearerToken string, namespace stri
 // It increases UnIdleCallCount by 1.
 func (c *OpenShiftClient) UnIdle(apiURL string, bearerToken string, namespace string, service string) error {
 	c.UnIdleCallCount++
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
 	return nil
 }
 
 // IsIdle mocks IsIdle method of client.OpenShiftClient.
 func (c *OpenShiftClient) IsIdle(apiURL string, bearerToken string, namespace string, service string) (int, error) {
+	if c.IdleError != "" {
+		return c.IdleState, fmt.Errorf(c.IdleError)
+	}
 	return c.IdleState, nil
 }
 
 // WhoAmI returns the name of the logged in user, aka the owner of the bearer token.
 func (c *OpenShiftClient) WhoAmI(apiURL string, bearerToken string) (string, error) {
+	if c.IdleError != "" {
+		return "foo", fmt.Errorf(c.IdleError)
+	}
 	return "foo", nil
 }
 
 // WatchBuilds mocks WatchBuilds method of client.OpenShiftClient.
 // It always returns nil.
 func (c *OpenShiftClient) WatchBuilds(apiURL string, bearerToken string, buildType string, callback func(model.Object) error) error {
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
 	return nil
 }
 
 // WatchDeploymentConfigs mocks WatchDeploymentConfigs method of client.OpenShiftClient.
 // It always returns nil.
 func (c *OpenShiftClient) WatchDeploymentConfigs(apiURL string, bearerToken string, nsSuffix string, callback func(model.DCObject) error) error {
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
 	return nil
 }
 

--- a/internal/testutils/mock/mock_response_writer.go
+++ b/internal/testutils/mock/mock_response_writer.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// ResponseWriter used by an HTTP handler to construct an HTTP response.
+// This is the mock implementation
+type ResponseWriter struct {
+	Buffer       bytes.Buffer
+	WriterStatus int
+}
+
+// Header returns the header map that will be sent by
+func (m *ResponseWriter) Header() (h http.Header) {
+	return http.Header{}
+}
+
+// Write writes the data to the connection as part of an HTTP reply.
+func (m *ResponseWriter) Write(p []byte) (n int, err error) {
+	m.Buffer.Write(p)
+	return len(p), nil
+}
+
+// WriteString write string to the request
+func (m *ResponseWriter) WriteString(s string) (n int, err error) {
+	m.Buffer.WriteString(s)
+	return len(s), nil
+}
+
+// WriteHeader sends an HTTP response header with the provided
+// status code.
+func (m *ResponseWriter) WriteHeader(i int) {
+	m.WriterStatus = i
+}
+
+// GetBody Get the body of the request as string
+func (m *ResponseWriter) GetBody() string {
+	return m.Buffer.String()
+}


### PR DESCRIPTION
Add a couple of tests along the way.

Some methods could not be tested (i.e: Info) since it needs some
refactoring. see fabric8-services/fabric8-jenkins-idler#169