### PR TITLE
Issue #175 Idle content-repository pod along with Jenkins

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -18,8 +18,9 @@ type JSError struct {
 type ReqFuncType func(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 
 func Test_success(t *testing.T) {
+	mosc := &mock.OpenShiftClient{}
 	mockidle := idler{
-		openShiftClient: &mock.OpenShiftClient{},
+		openShiftClient: mosc,
 		clusterView:     &mock.ClusterView{},
 	}
 	functions := []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle}
@@ -34,6 +35,7 @@ func Test_success(t *testing.T) {
 		function(writer, reader, nil)
 
 		require.Equal(t, http.StatusOK, writer.WriterStatus, fmt.Sprintf("Bad Error Code: %d", writer.WriterStatus))
+		require.Equal(t, mosc.IdleCallCount, 2, fmt.Sprintf("Idle was not called for 2 times but %d", mosc.IdleCallCount))
 	}
 }
 


### PR DESCRIPTION
Add content-repository pod to be idled along jenkins.

We didn't do anything complicated here, if we are going to idle jenkins we are
doing content-repository along the way, if user access jenkins.openshift.io and
then get the unidle apicall called we unidle the content-repository too.

We are not handling the scenario when the user is unidling manually, the
content-repository would be left unidled until the next idle round. That's a
bit stretchy scenario for the amount of work.