### PR TITLE
Issue #182 Add promotheus /metrics handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ lint: ## Runs golint
 
 .PHONY: validate_commits
 validate_commits: tools ## Validates git commit messages
-	git-validation -q -run short-subject,message_regexp='^(Fix\s)?(Issue\s)?#[0-9]+ [A-Z]+.*' -range $(START_COMMIT_MESSAGE_VALIDATION)...
+	git-validation -q -run short-subject,message_regexp='^(Fix\s)?(Issue\s)?#[0-9]+\s+[A-Z0-9]+.*' -range $(START_COMMIT_MESSAGE_VALIDATION)...
+
 
 .PHONY: clean
 clean: ## Deletes all build artifacts

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/cluster"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/openshift"
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/openshift/client"
+	"github.com/fabric8-services/fabric8-jenkins-idler/metric"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 )
@@ -24,6 +26,9 @@ var (
 	// they go along the main build detection logic of jenkins and don't have
 	// any specific scenarios.
 	JenkinsServices = []string{"jenkins", "content-repository"}
+
+	// Recorder to capture events
+	Recorder = metric.PrometheusRecorder{}
 )
 
 // IdlerAPI defines the REST endpoints of the Idler
@@ -61,6 +66,8 @@ type status struct {
 
 // NewIdlerAPI creates a new instance of IdlerAPI.
 func NewIdlerAPI(userIdlers *openshift.UserIdlerMap, clusterView cluster.View) IdlerAPI {
+	// Initialize metrics
+	Recorder.Initialize()
 	return &idler{
 		userIdlers:      userIdlers,
 		clusterView:     clusterView,
@@ -78,13 +85,19 @@ func (api *idler) Idle(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	}
 
 	for _, service := range JenkinsServices {
+		startTime := time.Now()
 		err = api.openShiftClient.Idle(openShiftAPI, openShiftBearerToken, ps.ByName("namespace"), service)
+		elapsedTime := time.Since(startTime).Seconds()
+
 		if err != nil {
 			log.Error(err)
+			Recorder.RecordReqDuration(service, "Idle", http.StatusInternalServerError, elapsedTime)
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
 			return
 		}
+
+		Recorder.RecordReqDuration(service, "Idle", http.StatusOK, elapsedTime)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -1,0 +1,58 @@
+package metric
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+var logger = log.WithFields(log.Fields{"component": "metrics"})
+
+var (
+	namespace = ""
+	subsystem = "service"
+)
+
+var (
+	reqLabels   = []string{"service", "operation", "code"}
+	reqDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "idler_request_duration_seconds",
+		Help:      "Bucketed histogram of processing time (s) of requests.",
+		Buckets:   prometheus.ExponentialBuckets(0.05, 2, 8),
+	}, reqLabels)
+)
+
+func registerMetrics() {
+	reqDuration = register(reqDuration, "idler_request_duration_seconds").(*prometheus.HistogramVec)
+}
+
+func register(c prometheus.Collector, name string) prometheus.Collector {
+	err := prometheus.Register(c)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return are.ExistingCollector
+		}
+		logger.
+			WithField("err", err).
+			WithField("metric_name", prometheus.BuildFQName(namespace, subsystem, name)).
+			Panic("Failed to register the prometheus metric")
+	}
+	logger.
+		WithField("metric_name", prometheus.BuildFQName(namespace, subsystem, name)).
+		Debug("metric registered successfully")
+	return c
+}
+
+func reportRequestDuration(jenkinsService, operation string, code int, elapsedTime float64) {
+	if jenkinsService != "" && operation != "" && elapsedTime != 0 && code != 0 {
+		reqDuration.WithLabelValues(jenkinsService, operation, codeVal(code)).Observe(elapsedTime)
+	}
+}
+
+func codeVal(status int) string {
+	code := (status - (status % 100)) / 100
+	return strconv.Itoa(code) + "xx"
+}

--- a/metric/recorder.go
+++ b/metric/recorder.go
@@ -1,0 +1,21 @@
+package metric
+
+// Recorder interface that encapsulates all logic of metrics
+type Recorder interface {
+	Initialize()
+	RecordReqDuration(jenkinsService, operation string, code int, elapsedTime float64)
+}
+
+// PrometheusRecorder struct used to record metrics to be consumed by Prometheus
+type PrometheusRecorder struct {
+}
+
+// Initialize all metrics
+func (pr PrometheusRecorder) Initialize() {
+	registerMetrics()
+}
+
+// RecordReqDuration records the duration of given operation in metrics system
+func (pr PrometheusRecorder) RecordReqDuration(jenkinsService, operation string, code int, elapsedTime float64) {
+	reportRequestDuration(jenkinsService, operation, code, elapsedTime)
+}

--- a/metric/recorder_test.go
+++ b/metric/recorder_test.go
@@ -1,0 +1,62 @@
+package metric
+
+import (
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestCodeVal(t *testing.T) {
+	tables := []struct {
+		in  int
+		out string
+	}{
+		{100, "1xx"},
+		{200, "2xx"},
+		{201, "2xx"},
+		{404, "4xx"},
+	}
+
+	for _, table := range tables {
+		actual := codeVal(table.in)
+		if table.out != actual {
+			t.Errorf("output was incorrect, want:%s, got:%s", table.out, actual)
+		}
+	}
+}
+func TestReqDurationMetric(t *testing.T) {
+	recorder := PrometheusRecorder{}
+	reqTimes := []time.Duration{51, 101, 201, 401, 801, 1601, 3201, 6401}
+	expectedBound := []float64{0.05, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4}
+	expectedCnt := []uint64{0, 1, 2, 3, 4, 5, 6, 7}
+
+	// add post method
+	for _, reqTime := range reqTimes {
+		startTime := time.Now().Add(time.Millisecond * -reqTime)
+		recorder.RecordReqDuration("jenkins", "idle", 200, time.Since(startTime).Seconds())
+	}
+
+	// validate
+	reqMetric, _ := reqDuration.GetMetricWithLabelValues("jenkins", "idle", "2xx")
+	m := &dto.Metric{}
+	reqMetric.Write(m)
+	checkHistogram(t, m, uint64(len(reqTimes)), expectedBound, expectedCnt)
+}
+
+func checkHistogram(t *testing.T, m *dto.Metric, expectedCount uint64, expectedBound []float64, expectedCnt []uint64) {
+	if expectedCount != m.Histogram.GetSampleCount() {
+		t.Errorf("Histogram count was incorrect, want: %d, got: %d",
+			expectedCount, m.Histogram.GetSampleCount())
+	}
+	for ind, bucket := range m.Histogram.GetBucket() {
+		if expectedBound[ind] != *bucket.UpperBound {
+			t.Errorf("Bucket upper bound was incorrect, want: %f, got: %f\n",
+				expectedBound[ind], *bucket.UpperBound)
+		}
+		if expectedCnt[ind] != *bucket.CumulativeCount {
+			t.Errorf("Bucket cumulative count was incorrect, want: %d, got: %d\n",
+				expectedCnt[ind], *bucket.CumulativeCount)
+		}
+	}
+}


### PR DESCRIPTION
This is a partial solution of #182. The `/metrics` handler was already introduced, but no custom metrics were reported yet.

This PR is a part of https://github.com/openshiftio/openshift.io/issues/2778 by providing a metric which collects the amount of time idle operation takes and the result code and make it available in Prometheus.