### PR TITLE
Issue #221 Build on RHEL

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,26 @@
+FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV LANG=en_US.utf8
+ENV INSTALL_PREFIX=/usr/local/f8
+
+# Create a non-root user and a group with the same name: "f8" USER_NAME=f8
+ENV USER_NAME=f8
+RUN useradd --no-create-home -s /bin/bash ${USER_NAME}
+
+COPY out/fabric8-jenkins-idler ${INSTALL_PREFIX}/bin/fabric8-jenkins-idler
+
+RUN mkdir -p /var/lib/pcp/config/pmda && \
+    chown -R ${USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod a+rw /var/lib/pcp/config/pmda && \
+    chmod -R ug+rw /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+COPY ./scripts/pcp/idler+pmcd.sh /idler+pmcd.sh
+EXPOSE 44321
+
+USER ${USER_NAME}
+
+WORKDIR ${INSTALL_PREFIX}
+ENTRYPOINT [ "/idler+pmcd.sh" ]
+
+EXPOSE 8080

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -16,7 +16,7 @@ function setup_build_environment() {
     [ -f inherit-env ] && . inherit-env
 
     # We need to disable selinux for now, XXX
-    /usr/sbin/setenforce 0
+    /usr/sbin/setenforce 0 || :
 
     yum -y install docker make golang git
     service docker start
@@ -35,7 +35,7 @@ function setup_golang() {
   # Show Go version
   go version
   # Setup GOPATH
-  mkdir $HOME/go $HOME/go/src $HOME/go/bin $HOME/go/pkg
+  mkdir -p $HOME/go $HOME/go/src $HOME/go/bin $HOME/go/pkg
   export GOPATH=$HOME/go
   export PATH=${GOPATH}/bin:$PATH
 }
@@ -59,9 +59,10 @@ setup_workspace
 
 cd $GOPATH/src/github.com/fabric8-services/fabric8-jenkins-idler
 echo "HEAD of repository `git rev-parse --short HEAD`"
+make login REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD}
 make image
 
 if [[ "$JOB_NAME" = "devtools-fabric8-jenkins-idler-build-master" ]]; then
     TAG=$(echo ${GIT_COMMIT} | cut -c1-${DEVSHIFT_TAG_LEN})
-    make push REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD} IMAGE_TAG=${TAG}
+    make push IMAGE_TAG=${TAG}
 fi


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

This PR will remain as a WIP until this PR is merged and validated:
https://github.com/fabric8-services/fabric8-auth/pull/432