### PR TITLE
Fix #141 Take built start time into account for active builds

### DIFF
--- a/internal/condition/build_condition_test.go
+++ b/internal/condition/build_condition_test.go
@@ -1,22 +1,23 @@
 package condition
 
 import (
-	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_non_user_creates_error(t *testing.T) {
 	user := "foo"
-	condition := NewBuildCondition(time.Duration(5) * time.Minute)
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	_, err := condition.Eval(user)
 	assert.Error(t, err, "Passing non User instances to Eval should return an error.")
 }
 
 func Test_eval_returns_true_if_there_are_no_builds(t *testing.T) {
 	user := model.NewUser("123", "foo")
-	condition := NewBuildCondition(time.Duration(5) * time.Minute)
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	condValue, err := condition.Eval(user)
 	assert.NoError(t, err)
 	assert.True(t, condValue, "Condition should evaluate to true.")
@@ -28,9 +29,68 @@ func Test_eval_return_false_when_active_build_exists(t *testing.T) {
 		Metadata: model.Metadata{
 			Name: "test build",
 		},
+		Status: model.Status{
+			StartTimestamp: model.BuildTime{Time: time.Now()},
+		},
 	}
-	condition := NewBuildCondition(time.Duration(5) * time.Minute)
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	condValue, err := condition.Eval(user)
 	assert.NoError(t, err)
 	assert.False(t, condValue, "Condition should evaluate to false.")
+}
+
+func Test_eval_return_true_when_activebuild_is_old(t *testing.T) {
+	type LStatus model.Status
+	oldTime, _ := time.Parse(
+		time.RFC3339,
+		"1979-04-16T16:30:41+00:00")
+	user := model.NewUser("123", "foo")
+	user.ActiveBuild = model.Build{
+		Metadata: model.Metadata{
+			Name: "test build",
+		},
+		Status: model.Status{
+			StartTimestamp: model.BuildTime{Time: oldTime},
+		},
+	}
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(10)*time.Hour)
+	condValue, err := condition.Eval(user)
+	assert.NoError(t, err)
+	assert.True(t, condValue, "Condition should evaluate to true.")
+}
+
+func Test_eval_completion_before_idletime_expires(t *testing.T) {
+	user := model.NewUser("123", "foo")
+	user.DoneBuild = model.Build{
+		Metadata: model.Metadata{
+			Name: "test build",
+		},
+		Status: model.Status{
+			CompletionTimestamp: model.BuildTime{Time: time.Now()},
+		},
+	}
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
+	condValue, err := condition.Eval(user)
+	assert.NoError(t, err)
+	assert.False(t, condValue, "Condition should evaluate to false.")
+}
+
+func Test_eval_completion_after_idletime_expires(t *testing.T) {
+	oldTime, _ := time.Parse(
+		time.RFC3339,
+		"1979-04-16T16:30:41+00:00")
+
+	user := model.NewUser("123", "foo")
+	user.DoneBuild = model.Build{
+		Metadata: model.Metadata{
+			Name: "test build",
+		},
+		Status: model.Status{
+			CompletionTimestamp: model.BuildTime{Time: oldTime},
+		},
+	}
+	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
+	condValue, err := condition.Eval(user)
+	assert.NoError(t, err)
+	assert.True(t, condValue, "Condition should evaluate to false.")
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -18,6 +18,9 @@ type Configuration interface {
 	// GetIdleAfter returns the number of minutes before Jenkins is idled.
 	GetIdleAfter() int
 
+	// GetIdleLongBuild returns how long it waits in hours for a long running build before idling
+	GetIdleLongBuild() int
+
 	// GetMaxRetries returns the maximum number of retries to idle resp. un-idle the Jenkins service.
 	GetMaxRetries() int
 

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -2,14 +2,16 @@ package configuration
 
 import (
 	"fmt"
-	"github.com/fabric8-services/fabric8-jenkins-idler/internal/util"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/util"
 )
 
 const (
+	defaultIdleLongBuild           = 3
 	defaultIdleAfter               = 45
 	defaultMaxRetries              = 3
 	defaultMaxRetriesQuietInterval = 30
@@ -35,6 +37,7 @@ func init() {
 
 	// timeouts and retry counts
 	settings["GetIdleAfter"] = Setting{"JC_IDLE_AFTER", strconv.Itoa(defaultIdleAfter), []func(interface{}, string) error{util.IsInt}}
+	settings["GetIdleLongBuild"] = Setting{"JC_IDLE_LONG_BUILD", strconv.Itoa(defaultIdleLongBuild), []func(interface{}, string) error{util.IsInt}}
 	settings["GetMaxRetries"] = Setting{"JC_MAX_RETRIES", strconv.Itoa(defaultMaxRetries), []func(interface{}, string) error{util.IsInt}}
 	settings["GetMaxRetriesQuietInterval"] = Setting{"JC_MAX_RETRIES_QUIET_INTERVAL", strconv.Itoa(defaultMaxRetriesQuietInterval), []func(interface{}, string) error{util.IsInt}}
 	settings["GetCheckInterval"] = Setting{"JC_CHECK_INTERVAL", strconv.Itoa(defaultCheckInterval), []func(interface{}, string) error{util.IsInt}}
@@ -71,6 +74,15 @@ func (c *EnvConfig) GetProxyURL() string {
 
 // GetIdleAfter returns the number of minutes before Jenkins is idled as set via default, config file, or environment variable.
 func (c *EnvConfig) GetIdleAfter() int {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := c.getConfigValueFromEnv(util.NameOfFunction(callPtr))
+
+	i, _ := strconv.Atoi(value)
+	return i
+}
+
+// GetIdleLongbuild returns the number of minutes before Jenkins is idled as set via default, config file, or environment variable.
+func (c *EnvConfig) GetIdleLongBuild() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := c.getConfigValueFromEnv(util.NameOfFunction(callPtr))
 

--- a/internal/configuration/env_config_test.go
+++ b/internal/configuration/env_config_test.go
@@ -46,6 +46,7 @@ func Test_default_values(t *testing.T) {
 	assert.NoError(t, err, "Creating the configuration failed unexpectedly.")
 	assert.False(t, config.GetDebugMode(), "The default value for profiling should be false.")
 	assert.Equal(t, config.GetIdleAfter(), defaultIdleAfter, "Unexpected default value for idle after.")
+	assert.Equal(t, config.GetIdleLongBuild(), defaultIdleLongBuild, "Unexpected default value for idle long build.")
 	assert.Equal(t, config.GetMaxRetries(), defaultMaxRetries, "Unexpected default value for number of unidle retries.")
 	assert.Equal(t, config.GetCheckInterval(), defaultCheckInterval, "Unexpected default value for number of unidle retries.")
 }

--- a/internal/model/openshift_objects.go
+++ b/internal/model/openshift_objects.go
@@ -135,7 +135,7 @@ type Project struct {
 
 // BuildTime is duration of the Build.
 type BuildTime struct {
-	time.Time
+	Time time.Time
 }
 
 // UnmarshalJSON gets time from raw (in the form of []byte) JSON object.

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -11,6 +11,7 @@ type Config struct {
 	TenantURL             string
 	ToggleURL             string
 	IdleAfter             int
+	IdleLongBuild         int
 	MaxRetries            int
 	MaxRetriesQuietPeriod int
 	CheckInterval         int
@@ -45,6 +46,11 @@ func (c *Config) GetToggleURL() string {
 // GetIdleAfter returns the number of minutes before Jenkins is idled.
 func (c *Config) GetIdleAfter() int {
 	return c.IdleAfter
+}
+
+// GetIdleLongBuild returns the number of minutes before Jenkins is idled.
+func (c *Config) GetIdleLongBuild() int {
+	return c.IdleLongBuild
 }
 
 // GetMaxRetries returns the maximum number of retries to idle resp. un-idle the Jenkins service.


### PR DESCRIPTION
++
* Improves logging of the request to give a reason why we are idling
* Improves testings (100% coverage on build_condition.go)