### PR TITLE
Add dry run mode mode

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -53,6 +53,9 @@ type Configuration interface {
 	// user account token
 	GetAuthGrantType() string
 
+	// GetDryRun returns if the idler is to be run in test mode or not. If dry run is set, no idling takes place
+	GetDryRun() bool
+
 	// Verify validates the configuration and returns an error in case the configuration is missing required settings
 	// or contains invalid settings. If the configuration is correct nil is returned.
 	Verify() util.MultiError

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -45,6 +45,7 @@ func init() {
 	// debug
 	settings["GetDebugMode"] = Setting{"JC_DEBUG_MODE", "false", []func(interface{}, string) error{util.IsBool}}
 	settings["GetFixedUuids"] = Setting{"JC_FIXED_UUIDS", "", []func(interface{}, string) error{}}
+	settings["GetDryRun"] = Setting{"JC_DRY_RUN", "false", []func(interface{}, string) error{}}
 }
 
 // Setting defines an element in the configuration of Jenkins Idler.
@@ -209,6 +210,13 @@ func (c *EnvConfig) Verify() util.MultiError {
 	}
 
 	return errors
+}
+
+// GetDryRun returns if dry run is enabled or not
+func (c *EnvConfig) GetDryRun() bool {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := c.getConfigValueFromEnv(util.NameOfFunction(callPtr))
+	return strings.ToLower(value) == "true"
 }
 
 func (c *EnvConfig) String() string {


### PR DESCRIPTION
This commit lets configuring the idler to not do any actual idling
but instead perform a dry run where the state of the cluster is
not changed by introducing an environment variable JC_DRY_RUN,
which is set to true will run idler in a test mode without really
idling.

Fixes #213