### PR TITLE
Serve idle/unidle reasons with API

### DIFF
--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -112,10 +112,14 @@ func (idler *UserIdler) checkIdle() error {
 			return err
 		}
 		if enabled {
-			idler.doIdle()
+			err := idler.doIdle()
+			// TODO: find a better way to update IdleStatus inside doIdle()
+			idler.user.IdleStatus = model.NewIdleStatus(err)
 		}
 	} else {
-		idler.doUnIdle()
+		err := idler.doUnIdle()
+		// TODO: find a better way to update IdleStatus inside doUnIdle()
+		idler.user.IdleStatus = model.NewUnidleStatus(err)
 	}
 
 	return nil

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -14,6 +14,47 @@ type User struct {
 	ActiveBuild       Build
 	DoneBuild         Build
 	JenkinsLastUpdate time.Time
+	IdleStatus        IdleStatus
+}
+
+// IdleStatus contains information about the idle/un-idle status like timestamp
+// and reasons of failure
+type IdleStatus struct {
+	Timestamp time.Time
+	Success   bool
+	Reason    string
+}
+
+// NewIdleStatus returns IdleStatus based on the error provided
+func NewIdleStatus(err error) IdleStatus {
+	if err != nil {
+		return IdleStatus{
+			Timestamp: time.Now().UTC(),
+			Success:   false,
+			Reason:    fmt.Sprintf("Failed to idle with error: %v", err),
+		}
+	}
+	return IdleStatus{
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		Reason:    "Successfully idled",
+	}
+}
+
+// NewUnidleStatus returns IdleStatus based on the error provided
+func NewUnidleStatus(err error) IdleStatus {
+	if err != nil {
+		return IdleStatus{
+			Timestamp: time.Now().UTC(),
+			Success:   false,
+			Reason:    fmt.Sprintf("Failed to un-idle with error: %v", err),
+		}
+	}
+	return IdleStatus{
+		Timestamp: time.Now().UTC(),
+		Success:   true,
+		Reason:    "Successfully un-idled",
+	}
 }
 
 // NewUser creates a new instance of a User given an id and name.

--- a/internal/model/user_test.go
+++ b/internal/model/user_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -10,4 +11,70 @@ func Test_String(t *testing.T) {
 	userAsString := user.String()
 
 	assert.Equal(t, userAsString, "HasBuilds:false HasActiveBuilds:false JenkinsLastUpdate:01 Jan 01 00:00 UTC", "Unexpected string format")
+}
+
+func TestNewIdleStatus(t *testing.T) {
+	idleError := fmt.Errorf("things are messed up")
+	tests := []struct {
+		name       string
+		inputError error
+		success    bool
+		reason     string
+	}{
+		{
+			name:       "test output with an error",
+			inputError: idleError,
+			success:    false,
+			reason:     fmt.Sprintf("Failed to idle with error: %v", idleError),
+		},
+		{
+			name:       "test output without an error",
+			inputError: nil,
+			success:    true,
+			reason:     "Successfully idled",
+		},
+	}
+
+	for _, test := range tests {
+		output := NewIdleStatus(test.inputError)
+		if output.Success != test.success {
+			t.Errorf("Expected success to be %v, got %v", test.success, output.Success)
+		}
+		if output.Reason != test.reason {
+			t.Errorf("Expected reason to be %v, got %v", test.reason, output.Reason)
+		}
+	}
+}
+
+func TestNewUnidleStatus(t *testing.T) {
+	unidleError := fmt.Errorf("things are messed up")
+	tests := []struct {
+		name       string
+		inputError error
+		success    bool
+		reason     string
+	}{
+		{
+			name:       "test output with an error",
+			inputError: unidleError,
+			success:    false,
+			reason:     fmt.Sprintf("Failed to un-idle with error: %v", unidleError),
+		},
+		{
+			name:       "test output without an error",
+			inputError: nil,
+			success:    true,
+			reason:     "Successfully un-idled",
+		},
+	}
+
+	for _, test := range tests {
+		output := NewUnidleStatus(test.inputError)
+		if output.Success != test.success {
+			t.Errorf("Expected success to be %v, got %v", test.success, output.Success)
+		}
+		if output.Reason != test.reason {
+			t.Errorf("Expected reason to be %v, got %v", test.reason, output.Reason)
+		}
+	}
 }


### PR DESCRIPTION
This commit adds an IdleStatus field to the JSON returned by
the API call at /api/idler/info/namespace. This field stores the
information about idling or unidling of that given namespace, and
if the operation was successful, and a reason if it was not.

Fixes #171 