### PR TITLE
Fix #241 Rename internal IsIdle method to State that returns a type

### DIFF
--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -177,7 +177,7 @@ func (idler *UserIdler) doIdle() error {
 		return err
 	}
 
-	if state > model.JenkinsIdled {
+	if state > model.PodIdled {
 		idler.incrementIdleAttempts()
 		for _, service := range JenkinsServices {
 
@@ -207,7 +207,7 @@ func (idler *UserIdler) doUnIdle() error {
 	if err != nil {
 		return err
 	}
-	if state != model.JenkinsIdled {
+	if state != model.PodIdled {
 		return nil
 	}
 
@@ -251,11 +251,11 @@ func (idler *UserIdler) isIdlerEnabled() (bool, error) {
 	return false, nil
 }
 
-func (idler *UserIdler) getJenkinsState() (int, error) {
+func (idler *UserIdler) getJenkinsState() (model.PodState, error) {
 	ns := idler.user.Name + jenkinsNamespaceSuffix
-	state, err := idler.openShiftClient.IsIdle(idler.openShiftAPI, idler.openShiftBearerToken, ns, jenkinsServiceName)
+	state, err := idler.openShiftClient.State(idler.openShiftAPI, idler.openShiftBearerToken, ns, jenkinsServiceName)
 	if err != nil {
-		return -1, err
+		return model.PodStateUnknown, err
 	}
 	return state, nil
 }

--- a/internal/idler/user_idler_test.go
+++ b/internal/idler/user_idler_test.go
@@ -123,7 +123,7 @@ func Test_number_of_idle_calls_are_capped(t *testing.T) {
 
 	user := model.User{ID: "42", Name: "John Doe"}
 	openShiftClient := &mock.OpenShiftClient{}
-	openShiftClient.IdleState = model.JenkinsRunning
+	openShiftClient.IdleState = model.PodRunning
 
 	config := &mock.Config{}
 	maxRetry := 10
@@ -170,7 +170,7 @@ func Test_number_of_unidle_calls_are_capped(t *testing.T) {
 	user := model.User{ID: "42", Name: "John Doe"}
 
 	openShiftClient := &mock.OpenShiftClient{}
-	openShiftClient.IdleState = model.JenkinsIdled
+	openShiftClient.IdleState = model.PodIdled
 
 	config := &mock.Config{}
 	maxRetry := 10

--- a/internal/model/openshift_objects.go
+++ b/internal/model/openshift_objects.go
@@ -9,14 +9,32 @@ import (
 
 // OpenShift related structs
 
+// PodState represents an different states of a Pod
+type PodState int
+
 const (
-	// JenkinsIdled represents the idled state of a Jenkins instance.
-	JenkinsIdled = 0
-	// JenkinsStarting state is when Jenkins is about to start.
-	JenkinsStarting = 1
-	// JenkinsRunning state is Jenkins is running.
-	JenkinsRunning = 2
+	// PodStateUnknown represents an unknown state of the Pod. Used usually with Error.
+	PodStateUnknown PodState = 0
+	// PodIdled represents the idled state of a Pod.
+	PodIdled = 1
+	// PodStarting state is when Pods are about to start.
+	PodStarting = 2
+	// PodRunning state is when Pods are running.
+	PodRunning = 3
 )
+
+func (state PodState) String() string {
+	states := [...]string{
+		"unknown",
+		"idled",
+		"starting",
+		"running",
+	}
+	if state < PodStateUnknown || state > PodRunning {
+		state = 0
+	}
+	return states[state]
+}
 
 // Object is Build Object.
 type Object struct {

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -9,7 +9,7 @@ import (
 // OpenShiftClient is a client for OpenShift API
 // It is a mock implementation of client.OpenShiftClient.
 type OpenShiftClient struct {
-	IdleState       int
+	IdleState       model.PodState
 	IdleCallCount   int
 	UnIdleCallCount int
 	IdleError       string
@@ -35,8 +35,8 @@ func (c *OpenShiftClient) UnIdle(apiURL string, bearerToken string, namespace st
 	return nil
 }
 
-// IsIdle mocks IsIdle method of client.OpenShiftClient.
-func (c *OpenShiftClient) IsIdle(apiURL string, bearerToken string, namespace string, service string) (int, error) {
+// State mocks State method of client.OpenShiftClient.
+func (c *OpenShiftClient) State(apiURL string, bearerToken string, namespace string, service string) (model.PodState, error) {
 	if c.IdleError != "" {
 		return c.IdleState, fmt.Errorf(c.IdleError)
 	}


### PR DESCRIPTION
OpenshiftClient IsIdle method although sound like it returns a bool
actually returns an int. This method has been renames to return a
type `PodState` which also implements the `stringer` interface so
that the state can be easily (json) marshalled. As a side-effect
of this, the `state` api is simplified a bit.