### PR TITLE
Increase max retry count from 3 to 10

### DIFF
--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultIdleLongBuild           = 3
 	defaultIdleAfter               = 45
-	defaultMaxRetries              = 3
+	defaultMaxRetries              = 10
 	defaultMaxRetriesQuietInterval = 30
 	defaultCheckInterval           = 15
 )

--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -36,7 +36,7 @@ objects:
           - name: JC_CHECK_INTERVAL
             value: "15"
           - name: JC_MAX_RETRIES
-            value: "3"
+            value: "10"
           - name: JC_MAX_RETRIES_QUIET_INTERVAL
             value: "30"
           - name: JC_JENKINS_PROXY_API_URL


### PR DESCRIPTION
This commit changes the default value of max retry count from 3 to
10. This is being done because idler often fails to un-idle the
content-repository because the max retry count is reached leading
to intermittent failures.