### PR TITLE
Issue #163 Could not find condition 'Available'

### DIFF
--- a/internal/openshift/controller.go
+++ b/internal/openshift/controller.go
@@ -147,7 +147,9 @@ func (c *controllerImpl) HandleDeploymentConfig(dc model.DCObject) error {
 
 	condition, err := dc.Object.Status.GetByType(availableCond)
 	if err != nil {
-		return err
+		log.Infof("Available condition not present (%s) in the list of conditions - SKIPPING", err)
+		// stop processing since the pod isn't available yet
+		return nil
 	}
 
 	// TODO Verify if we need Generation vs. ObservedGeneration


### PR DESCRIPTION
The error "Error from DC callback: could not find condition 'Available'
" occurs when we don't have any available deployments.If a pod is
coming up the condition would be 'Progressing' and if it fails it would
be 'ReplicaFailure'. To find that there are no available deployments is
an information rather than an error, while watching DeploymentConfigs

Fixes #163 