### PR TITLE
Fix the script to stop services correctly

### DIFF
--- a/scripts/setupLocalIdler.sh
+++ b/scripts/setupLocalIdler.sh
@@ -275,9 +275,10 @@ unsetEnv() {
 #   None
 ###############################################################################
 stop() {
-    pids=$(pgrep -a -f -d " " "setupLocalIdler.sh start")
-    pids+=$(pgrep -a -f -d " " "oc --config $(dirname $0)/config")
-    kill -9 ${pids}
+    pgrep -a -f "oc --config $(dirname "$0")/config" | cut -f1 -d ' '  |
+    xargs --no-run-if-empty --verbose  kill -9 || true
+    pgrep -a -f "$(basename "$0") start" | cut -f1 -d ' '  |
+    xargs --no-run-if-empty --verbose kill -9 || true
 }
 
 case "$1" in


### PR DESCRIPTION
Thanks @sthaha

This is the trace I get right now without this fix.

```
./scripts/setupLocalIdler.sh: line 280: kill: bash: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/setupLocalIdler.sh: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: start: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: bash: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/setupLocalIdler.sh: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: start: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: bash: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/setupLocalIdler.sh: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: start17244: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: oc: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: --config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: port-forward: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: jenkins-proxy-155-qkl2k: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: 9101:9091: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: oc: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: --config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: port-forward: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: f8toggles-33-k7ztx: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: 9103:4242: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: oc: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: --config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: ./scripts/config: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: port-forward: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: f8tenant-491-cprsz: arguments must be process or job IDs
./scripts/setupLocalIdler.sh: line 280: kill: 9102:8080: arguments must be process or job IDs
```