### PR TITLE
Issue #252 Added API to reset pods

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -54,10 +54,31 @@
   version = "v1.3.1"
 
 [[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
+  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
   branch = "master"
@@ -168,7 +189,13 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["websocket"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+    "websocket"
+  ]
   revision = "e0c57d8f86c17f0724497efcb3bc617e82834821"
 
 [[projects]]
@@ -177,9 +204,71 @@
   packages = ["unix"]
   revision = "89ac7f292d17a339edab4de8efcba5d8672ff661"
 
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
+  name = "k8s.io/api"
+  packages = ["core/v1"]
+  revision = "73d903622b7391f3312dcbac6483fed484e185f8"
+  source = "github.com/openshift/kubernetes-api"
+  version = "kubernetes-1.10.0"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/errors",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
+  revision = "ed135c5b96450fd24e5e981c708114fbbd950697"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bb69474f6c7a21658d3a84712f2148b8deedc7046dae134b277e7dfe86f56e3b"
+  inputs-digest = "2f4f1ba91a7a9edaafa5bdeb25db2b6991c75cd3f9bcaee1d069aaafc4d263b3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,6 +18,11 @@
   name = "github.com/stretchr/testify"
   version = "=v1.1.4"
 
+[[constraint]]
+  name = "k8s.io/api"
+  source = "github.com/openshift/kubernetes-api"
+  version = "kubernetes-1.10.2"
+
 [[override]]
   name = "github.com/satori/go.uuid"
   revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -226,14 +226,16 @@ func (api *idler) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	openShiftAPI, openShiftBearerToken, err := api.getURLAndToken(r)
 	if err != nil {
 		logger.Error(err)
-		writeResponse(w, http.StatusBadRequest, fmt.Sprintf("{\"error\": \"%q\"}", err))
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
 		return
 	}
 
 	err = api.openShiftClient.Reset(openShiftAPI, openShiftBearerToken, ps.ByName("namespace"))
 	if err != nil {
 		logger.Error(err)
-		writeResponse(w, http.StatusInternalServerError, fmt.Sprintf("{\"error\": \"%q\"}", err))
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
 		return
 	}
 
@@ -268,7 +270,7 @@ func (api idler) isJenkinsUnIdled(openshiftURL, openshiftToken, namespace string
 func respondWithError(w http.ResponseWriter, status int, err error) {
 	log.Error(err)
 	w.WriteHeader(status)
-	w.Write([]byte(fmt.Sprintf("{\"error\": \"%q\"}", err)))
+	w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
 }
 
 type responseError struct {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -229,7 +229,7 @@ func (api *idler) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	err = api.openShiftClient.Reset(openShiftAPI, openShiftBearerToken, ps.ByName("namespace"), "jenkins")
+	err = api.openShiftClient.Reset(openShiftAPI, openShiftBearerToken, ps.ByName("namespace"))
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -220,20 +220,20 @@ func (api *idler) Info(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 }
 
 func (api *idler) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+
+	logger := log.WithFields(log.Fields{"component": "api", "function": "Reset"})
+
 	openShiftAPI, openShiftBearerToken, err := api.getURLAndToken(r)
 	if err != nil {
-		log.Error(err)
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
+		logger.Error(err)
+		writeResponse(w, http.StatusBadRequest, fmt.Sprintf("{\"error\": \"%q\"}", err))
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
 	err = api.openShiftClient.Reset(openShiftAPI, openShiftBearerToken, ps.ByName("namespace"))
 	if err != nil {
-		log.Error(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
+		logger.Error(err)
+		writeResponse(w, http.StatusInternalServerError, fmt.Sprintf("{\"error\": \"%q\"}", err))
 		return
 	}
 
@@ -268,7 +268,7 @@ func (api idler) isJenkinsUnIdled(openshiftURL, openshiftToken, namespace string
 func respondWithError(w http.ResponseWriter, status int, err error) {
 	log.Error(err)
 	w.WriteHeader(status)
-	w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
+	w.Write([]byte(fmt.Sprintf("{\"error\": \"%q\"}", err)))
 }
 
 type responseError struct {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -27,6 +27,7 @@ func Test_success(t *testing.T) {
 	functions := []ReqFuncType{
 		mockidle.Idle, mockidle.UnIdle,
 		mockidle.IsIdle, mockidle.Status,
+		mockidle.Reset,
 	}
 
 	params := httprouter.Params{
@@ -52,7 +53,7 @@ func Test_fail(t *testing.T) {
 		openShiftClient: &mock.OpenShiftClient{},
 		clusterView:     &mock.ClusterView{},
 	}
-	functions := []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle}
+	functions := []ReqFuncType{mockidle.Idle, mockidle.UnIdle, mockidle.IsIdle, mockidle.Reset}
 	for _, function := range functions {
 		reader, _ := http.NewRequest("GET", "/", nil)
 		writer := &mock.ResponseWriter{}

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 var logger = log.WithFields(log.Fields{"component": "openshift-client"})
@@ -27,6 +28,7 @@ type OpenShiftClient interface {
 	WhoAmI(apiURL string, bearerToken string) (string, error)
 	WatchBuilds(apiURL string, bearerToken string, buildType string, callback func(model.Object) error) error
 	WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error
+	Reset(apiURL string, bearerToken string, namespace string, service string) error
 }
 
 type user struct {
@@ -140,6 +142,56 @@ func (o openShift) Idle(apiURL string, bearerToken string, namespace string, ser
 		return errors.New("could not update DeploymentConfig with replica count")
 	}
 
+	return
+}
+
+// Reset deletes a pod and start a new one
+func (o openShift) Reset(apiURL string, bearerToken string, namespace string, service string) (err error) {
+	logger.Info("reseting " + service + " in " + namespace)
+
+	req, err := o.reqAPI(apiURL, bearerToken, "GET", namespace, "pods", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := o.do(req)
+	if err != nil {
+		return err
+	}
+
+	defer bodyClose(resp)
+
+	podList := &v1.PodList{}
+	err = json.NewDecoder(resp.Body).Decode(podList)
+	if err != nil {
+		return err
+	}
+
+	for _, element := range podList.Items {
+
+		podName := element.GetName()
+		if strings.Contains(podName, "deploy") {
+			continue
+		}
+
+		log.Infof("Reseting the pod " + podName)
+		req, err := o.reqAPI(apiURL, bearerToken, "DELETE", namespace, "pods/"+podName, nil)
+		if err != nil {
+			return err
+		}
+		_, err = o.do(req)
+		if err != nil {
+			return err
+		}
+		/*
+			defer bodyClose(resp)
+
+			status := &v1.PodStatus{}
+			err = json.NewDecoder(resp.Body).Decode(status)
+			if err != nil {
+				return err
+			}
+		*/
+	}
 	return
 }
 

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -28,7 +28,7 @@ type OpenShiftClient interface {
 	WhoAmI(apiURL string, bearerToken string) (string, error)
 	WatchBuilds(apiURL string, bearerToken string, buildType string, callback func(model.Object) error) error
 	WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error
-	Reset(apiURL string, bearerToken string, namespace string, service string) error
+	Reset(apiURL string, bearerToken string, namespace string) error
 }
 
 type user struct {
@@ -146,8 +146,8 @@ func (o openShift) Idle(apiURL string, bearerToken string, namespace string, ser
 }
 
 // Reset deletes a pod and start a new one
-func (o openShift) Reset(apiURL string, bearerToken string, namespace string, service string) (err error) {
-	logger.Info("reseting " + service + " in " + namespace)
+func (o openShift) Reset(apiURL string, bearerToken string, namespace string) (err error) {
+	logger.Info("reseting pods in " + namespace)
 
 	req, err := o.reqAPI(apiURL, bearerToken, "GET", namespace, "pods", nil)
 	if err != nil {

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 var logger = log.WithFields(log.Fields{"component": "openshift-client"})
@@ -146,8 +146,8 @@ func (o openShift) Idle(apiURL string, bearerToken string, namespace string, ser
 }
 
 // Reset deletes a pod and start a new one
-func (o openShift) Reset(apiURL string, bearerToken string, namespace string) (err error) {
-	logger.Info("reseting pods in " + namespace)
+func (o openShift) Reset(apiURL string, bearerToken string, namespace string) error {
+	logger.Infof("resetting pods in " + namespace)
 
 	req, err := o.reqAPI(apiURL, bearerToken, "GET", namespace, "pods", nil)
 	if err != nil {
@@ -173,7 +173,7 @@ func (o openShift) Reset(apiURL string, bearerToken string, namespace string) (e
 			continue
 		}
 
-		log.Infof("Reseting the pod " + podName)
+		log.Infof("Reseting the pod %q", podName)
 		req, err := o.reqAPI(apiURL, bearerToken, "DELETE", namespace, "pods/"+podName, nil)
 		if err != nil {
 			return err
@@ -192,7 +192,7 @@ func (o openShift) Reset(apiURL string, bearerToken string, namespace string) (e
 			}
 		*/
 	}
-	return
+	return nil
 }
 
 // UnIdle scales up the jenkins pod in the given openShift namespace.

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -146,7 +146,7 @@ func (o openShift) Idle(apiURL string, bearerToken string, namespace string, ser
 }
 
 // Reset deletes a pod and start a new one
-func (o openShift) Reset(apiURL string, bearerToken string, namespace string) error {
+func (o *openShift) Reset(apiURL string, bearerToken string, namespace string) error {
 	logger.Infof("resetting pods in " + namespace)
 
 	req, err := o.reqAPI(apiURL, bearerToken, "GET", namespace, "pods", nil)
@@ -178,19 +178,12 @@ func (o openShift) Reset(apiURL string, bearerToken string, namespace string) er
 		if err != nil {
 			return err
 		}
-		_, err = o.do(req)
+
+		resp, err = o.do(req)
 		if err != nil {
 			return err
 		}
-		/*
-			defer bodyClose(resp)
-
-			status := &v1.PodStatus{}
-			err = json.NewDecoder(resp.Body).Decode(status)
-			if err != nil {
-				return err
-			}
-		*/
+		defer bodyClose(resp)
 	}
 	return nil
 }

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -173,7 +173,7 @@ func (o *openShift) Reset(apiURL string, bearerToken string, namespace string) e
 			continue
 		}
 
-		log.Infof("Reseting the pod %q", podName)
+		log.Infof("Resetting the pod %q", podName)
 		req, err := o.reqAPI(apiURL, bearerToken, "DELETE", namespace, "pods/"+podName, nil)
 		if err != nil {
 			return err

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -104,5 +104,8 @@ func CreateAPIRouter(api api.IdlerAPI) *httprouter.Router {
 	router.GET("/api/idler/cluster", api.ClusterDNSView)
 	router.GET("/api/idler/cluster/", api.ClusterDNSView)
 
+	router.GET("/api/idler/reset/:namespace", api.Reset)
+	router.GET("/api/idler/reset/:namespace/", api.Reset)
+
 	return router
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -104,8 +104,8 @@ func CreateAPIRouter(api api.IdlerAPI) *httprouter.Router {
 	router.GET("/api/idler/cluster", api.ClusterDNSView)
 	router.GET("/api/idler/cluster/", api.ClusterDNSView)
 
-	router.GET("/api/idler/reset/:namespace", api.Reset)
-	router.GET("/api/idler/reset/:namespace/", api.Reset)
+	router.POST("/api/idler/reset/:namespace", api.Reset)
+	router.POST("/api/idler/reset/:namespace/", api.Reset)
 
 	return router
 }

--- a/internal/testutils/mock/mock_idler_api.go
+++ b/internal/testutils/mock/mock_idler_api.go
@@ -47,6 +47,12 @@ func (i *IdlerAPI) Status(w http.ResponseWriter, r *http.Request, ps httprouter.
 	w.WriteHeader(http.StatusOK)
 }
 
+// Reset mock resets pods
+func (i *IdlerAPI) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.Write([]byte("Reset"))
+	w.WriteHeader(http.StatusOK)
+}
+
 // ClusterDNSView writes a JSON representation of the current cluster state to the response writer.
 func (i *IdlerAPI) ClusterDNSView(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	w.Write([]byte("GetClusterDNSView"))

--- a/internal/testutils/mock/mock_idler_api.go
+++ b/internal/testutils/mock/mock_idler_api.go
@@ -49,8 +49,8 @@ func (i *IdlerAPI) Status(w http.ResponseWriter, r *http.Request, ps httprouter.
 
 // Reset mock resets pods
 func (i *IdlerAPI) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Write([]byte("Reset"))
 	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Reset"))
 }
 
 // ClusterDNSView writes a JSON representation of the current cluster state to the response writer.

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -43,6 +43,14 @@ func (c *OpenShiftClient) State(apiURL string, bearerToken string, namespace str
 	return c.IdleState, nil
 }
 
+// Reset deletes a pod and start a new one
+func (c *OpenShiftClient) Reset(apiURL string, bearerToken string, namespace string) (err error) {
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
+	return nil
+}
+
 // WhoAmI returns the name of the logged in user, aka the owner of the bearer token.
 func (c *OpenShiftClient) WhoAmI(apiURL string, bearerToken string) (string, error) {
 	if c.IdleError != "" {

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -44,7 +44,7 @@ func (c *OpenShiftClient) State(apiURL string, bearerToken string, namespace str
 }
 
 // Reset deletes a pod and start a new one
-func (c *OpenShiftClient) Reset(apiURL string, bearerToken string, namespace string) (err error) {
+func (c *OpenShiftClient) Reset(apiURL string, bearerToken string, namespace string) error {
 	if c.IdleError != "" {
 		return fmt.Errorf(c.IdleError)
 	}


### PR DESCRIPTION
This PR adds an API to reset jenkins and content repository pods.
It does so by utilizing delete pods API of kubernetes, since kubernetes
is supposed to maintain the `scale`, it will make sure to start new
pods while it deletes the old ones.

Fixes #252 