### PR TITLE
Issue #255 Use functions for writing response

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -273,9 +273,9 @@ func (api idler) isJenkinsUnIdled(openshiftURL, openshiftToken, namespace string
 
 func respondWithError(w http.ResponseWriter, status int, err error) {
 	log.Error(err)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	w.Write([]byte(fmt.Sprintf("{\"error\": \"%s\"}", err)))
-	w.Header().Set("Content-Type", "application/json")
 }
 
 type responseError struct {
@@ -316,12 +316,11 @@ func (s *statusResponse) SetState(state model.PodState) *statusResponse {
 type any interface{}
 
 func writeResponse(w http.ResponseWriter, status int, response any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, fmt.Errorf("Could not serialize the response: %s", err))
 		return
 	}
-
-	w.WriteHeader(status)
-	w.Header().Set("Content-Type", "application/json")
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/testutils/mock"
@@ -147,4 +149,18 @@ func Test_Status_BadRequest_fail(t *testing.T) {
 	require.Equal(t, sr.Errors[0].Code, tokenFetchFailed, "Error must have a code")
 	require.Contains(t, sr.Errors[0].Description,
 		"failed to obtain openshift token", "Error must have a description")
+}
+
+func Test_writeFunctions(t *testing.T) {
+	w := httptest.NewRecorder()
+	testStatus := http.StatusBadRequest
+	writeResponse(w, testStatus, nil)
+	require.Equal(t, testStatus, w.Code, "in writeResponse, response was written before setting the HTTP status code")
+
+	w = httptest.NewRecorder()
+	testStatus = http.StatusInternalServerError
+	err := errors.New("Mock error")
+	respondWithError(w, testStatus, err)
+	require.Equal(t, testStatus, w.Code, "in respondWithError, response was written before setting the HTTP status code")
+
 }


### PR DESCRIPTION
Code for writing response(objects or errors) is repeated a lot.
Utilize functions writeResponse and respondWithError for here.
Move functions to their appropriate places.

Fixes #255