### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ LD_FLAGS := -X github.com/fabric8-services/fabric8-jenkins-idler/internal/versio
 AUTH_GEN_DIR=internal/auth/client
 
 # Misc
-START_COMMIT_MESSAGE_VALIDATION = f3cb0bf1fccf06c43298f4667757e774a89b1062
 .DEFAULT_GOAL := help
 
 # Check that given variables are set and all have non-empty values,
@@ -111,7 +110,16 @@ lint: ## Runs golint
 
 .PHONY: validate_commits
 validate_commits: tools ## Validates git commit messages
-	git-validation -q -run short-subject,message_regexp='^(Fix\s)?(Issue\s)?#[0-9]+\s+[A-Z0-9]+.*' -range $(START_COMMIT_MESSAGE_VALIDATION)...
+ifeq ($(origin TRAVIS_COMMIT_RANGE), undefined)
+	git-validation  \
+			-run short-subject,message_regexp='^(Revert\s*)?(Fix\s*)?(Issue\s*)?#[0-9]+ [A-Z]+.*' \
+			-range `git rev-parse master@{u}`...HEAD
+else
+	git-validation  \
+			-run short-subject,message_regexp='^(Revert\s*)?(Fix\s*)?(Issue\s*)?#[0-9]+ [A-Z]+.*' \
+			-range $$TRAVIS_COMMIT_RANGE
+
+endif
 
 .PHONY: clean
 clean: ## Deletes all build artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-REGISTRY_URI = push.registry.devshift.net
+REGISTRY_URI = quay.io
 REGISTRY_NS = fabric8-services
 REGISTRY_IMAGE = fabric8-jenkins-idler
 
 ifeq ($(TARGET),rhel)
 	DOCKERFILE_DEPLOY := Dockerfile.deploy.rhel
-	REGISTRY_URL = ${REGISTRY_URI}/osio-prod/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	REGISTRY_URL = ${REGISTRY_URI}/rhel-${REGISTRY_NS}-${REGISTRY_IMAGE}
 else
 	DOCKERFILE_DEPLOY := Dockerfile.deploy
-	REGISTRY_URL = ${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	REGISTRY_URL = ${REGISTRY_URI}/${REGISTRY_NS}-${REGISTRY_IMAGE}
 endif
 
 IMAGE_TAG ?= $(shell git rev-parse --short HEAD)

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -12,8 +12,9 @@ set -e
 #   None
 ###################################################################################
 function setup_build_environment() {
-    [ -f jenkins-env ] && cat jenkins-env | grep -e GIT -e DEVSHIFT -e JOB_NAME > inherit-env
-    [ -f inherit-env ] && . inherit-env
+    if [ -f jenkins-env.json ]; then
+      eval "$(./env-toolkit load -f jenkins-env.json -r ^GIT ^DEVSHIFT ^QUAY ^JOB_NAME$)"
+    fi
 
     # We need to disable selinux for now, XXX
     /usr/sbin/setenforce 0 || :
@@ -59,7 +60,7 @@ setup_workspace
 
 cd $GOPATH/src/github.com/fabric8-services/fabric8-jenkins-idler
 echo "HEAD of repository `git rev-parse --short HEAD`"
-make login REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD}
+make login REGISTRY_USER=${QUAY_USERNAME} REGISTRY_PASSWORD=${QUAY_PASSWORD}
 make image
 
 if [[ "$JOB_NAME" = "devtools-fabric8-jenkins-idler-build-master" ]]; then

--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -125,7 +125,7 @@ objects:
     type: ClusterIP
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-jenkins-idler
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-idler
   required: true
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/953