### PR TITLE
Issue #4127 Remove content repository

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -46,7 +46,7 @@ func Test_success(t *testing.T) {
 		function(writer, reader, params)
 
 		require.Equal(t, http.StatusOK, writer.WriterStatus, fmt.Sprintf("Bad Error Code: %d", writer.WriterStatus))
-		require.Equal(t, mosc.IdleCallCount, 2, fmt.Sprintf("Idle was not called for 2 times but %d", mosc.IdleCallCount))
+		require.Equal(t, mosc.IdleCallCount, 1, fmt.Sprintf("Idle was not called for 1 times but %d", mosc.IdleCallCount))
 	}
 }
 

--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -21,7 +21,7 @@ var logger = log.WithFields(log.Fields{"component": "user-idler"})
 // JenkinsServices is an array of all the services getting idled or unidled
 // they go along the main build detection logic of jenkins and don't have
 // any specific scenarios.
-var JenkinsServices = []string{"jenkins", "content-repository"}
+var JenkinsServices = []string{"jenkins"}
 
 const (
 	bufferSize             = 10

--- a/internal/idler/user_idler_test.go
+++ b/internal/idler/user_idler_test.go
@@ -126,7 +126,7 @@ func Test_number_of_idle_calls_are_capped(t *testing.T) {
 	openShiftClient.IdleState = model.PodRunning
 
 	config := &mock.Config{}
-	maxRetry := 10
+	maxRetry := 5
 	config.MaxRetries = maxRetry
 	features := mock.NewMockFeatureToggle([]string{"42"})
 	tenantService := &mock.TenantService{}
@@ -173,7 +173,7 @@ func Test_number_of_unidle_calls_are_capped(t *testing.T) {
 	openShiftClient.IdleState = model.PodIdled
 
 	config := &mock.Config{}
-	maxRetry := 10
+	maxRetry := 5
 	config.MaxRetries = maxRetry
 
 	features := mock.NewMockFeatureToggle([]string{"42"})


### PR DESCRIPTION
After content repository is removed(part of
https://github.com/openshiftio/openshift.io/issues/3895), we will not
need to idle/unidle it. This commit removes content repository from
list of services to be idled/unidled.

Issue: https://github.com/openshiftio/openshift.io/issues/4127