### PR TITLE
Issue #143 Check the DELETED event on Watch Builds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -164,6 +164,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -239,7 +245,6 @@
   version = "kubernetes-1.10.0"
 
 [[projects]]
-  branch = "master"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/resource",
@@ -264,11 +269,12 @@
     "pkg/watch",
     "third_party/forked/golang/reflect"
   ]
-  revision = "ed135c5b96450fd24e5e981c708114fbbd950697"
+  revision = "302974c03f7e50f16561ba237db776ab93594ef6"
+  version = "kubernetes-1.10.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2f4f1ba91a7a9edaafa5bdeb25db2b6991c75cd3f9bcaee1d069aaafc4d263b3"
+  inputs-digest = "7b0cfa464697bc4884c18f29fdbd9e508824af682085aef599b9868b94fca5ac"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,6 +23,10 @@
   source = "github.com/openshift/kubernetes-api"
   version = "kubernetes-1.10.2"
 
+[[constraint]]
+  name = "k8s.io/apimachinery"
+  version = "kubernetes-1.10.2"
+
 [[override]]
   name = "github.com/satori/go.uuid"
   revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"

--- a/internal/model/openshift_objects.go
+++ b/internal/model/openshift_objects.go
@@ -198,12 +198,13 @@ func (s DCStatus) GetByType(t string) (Condition, error) {
 }
 
 // Phases are points in the build lifecycle.
+// https://github.com/openshift/origin/blob/1017d1d8ca3611267e3993742a2c4fb06f65e449/pkg/build/apis/build/types.go#L403
 var Phases = map[string]int{
-	"Finished":  0,
-	"Complete":  0,
-	"Failed":    0,
-	"Cancelled": 0,
-	"Pending":   1,
 	"New":       1,
+	"Pending":   1,
 	"Running":   1,
+	"Failed":    0,
+	"Complete":  0,
+	"Error":     0,
+	"Cancelled": 0,
 }

--- a/internal/openshift/controller_test.go
+++ b/internal/openshift/controller_test.go
@@ -1,10 +1,11 @@
 package openshift
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/testutils/common"
-	"github.com/fabric8-services/fabric8-jenkins-idler/internal/util"
 
 	"context"
 	"io"
@@ -106,7 +107,7 @@ func testWithStateChange(t *testing.T, obj model.Object) {
 func testWithPhaseChange(t *testing.T, obj model.Object, phase string, eventType string) {
 	obj.Type = eventType
 	obj.Object.Status.Phase = phase
-	obj.Object.Metadata.Name = util.RandomString(8)
+	obj.Object.Metadata.Name = strconv.Itoa(rand.Intn(1000))
 
 	ci := controller.(*controllerImpl)
 	err := controller.HandleBuild(obj)

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"math/rand"
-	"strconv"
 	"strings"
 )
 
@@ -24,9 +22,4 @@ func Contains(list []string, s string) bool {
 		}
 	}
 	return false
-}
-
-// RandomString returns random string of length len
-func RandomString(len int) string {
-	return strconv.Itoa(rand.Intn(1000))
 }

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"math/rand"
+	"strconv"
 	"strings"
 )
 
@@ -22,4 +24,9 @@ func Contains(list []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// RandomString returns random string of length len
+func RandomString(len int) string {
+	return strconv.Itoa(rand.Intn(1000))
 }


### PR DESCRIPTION
Currently we look at Object.Status.Phase to check the status of build.
This approach works, except for DELETED event. OpenShift would show the
previous phase on deleting, giving us a wrong impression of build
status.
Check for o.Type as well.

After this change, if we reset the environment, we won't see any active builds as well used to see earlier (OK Tested Locally)
but the previous build of the user will still be shown in the done build, which I think is appropriate, so no need to change that.

Fixed #143

