### PR TITLE
Refactor openshift event watcher code

### DIFF
--- a/cmd/fabric8-jenkins-idler/idler_test.go
+++ b/cmd/fabric8-jenkins-idler/idler_test.go
@@ -54,10 +54,10 @@ func Test_graceful_shutdown(t *testing.T) {
 
 	idler.Run()
 
-	logMessages := extractLogMessages(hook.Entries)
+	logMessages := extractLogMessages(hook.AllEntries())
+	assert.Contains(t, logMessages, "Stopping to watch openshift build configuration changes.", "Idler shutdown completion should have been logged")
+	assert.Contains(t, logMessages, "Stopping to watch openshift deployment configuration changes.", "Idler shutdown completion should have been logged")
 	assert.Contains(t, logMessages, "Idler successfully shut down.", "Idler shutdown completion should have been logged")
-	assert.Contains(t, logMessages, "Stopping to watch openShift build configuration changes.", "Idler shutdown completion should have been logged")
-	assert.Contains(t, logMessages, "Stopping to watch openShift deployment configuration changes.", "Idler shutdown completion should have been logged")
 }
 
 func extractLogMessages(entries []*log.Entry) []string {


### PR DESCRIPTION
What do you feel about this?

* Simplifies the event watcher part by moving it to separate functions
* uses a `task` struct to hold  wg, and context passed across all functions
