### PR TITLE
Increase verbosity of idler logs

### DIFF
--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -1,11 +1,13 @@
 package condition
 
 import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 type TrueCondition struct {
@@ -41,7 +43,7 @@ func Test_all_conditions_true(t *testing.T) {
 	conditions.Add("true-2", &TrueCondition{})
 	conditions.Add("true-3", &TrueCondition{})
 
-	eval, err := conditions.Eval(nil)
+	eval, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
 	assert.True(t, eval, "Should evaluate to true.")
@@ -53,7 +55,7 @@ func Test_all_conditions_false(t *testing.T) {
 	conditions.Add("false-2", &FalseCondition{})
 	conditions.Add("false-3", &FalseCondition{})
 
-	eval, err := conditions.Eval(nil)
+	eval, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
 	assert.False(t, eval, "Should evaluate to false.")
@@ -65,7 +67,7 @@ func Test_mixed_conditions(t *testing.T) {
 	conditions.Add("true-2", &TrueCondition{})
 	conditions.Add("false-1", &FalseCondition{})
 
-	eval, err := conditions.Eval(nil)
+	eval, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
 	assert.False(t, eval, "Should evaluate to false.")
@@ -78,7 +80,7 @@ func Test_error_conditions(t *testing.T) {
 	conditions.Add("true-2", &TrueCondition{})
 	conditions.Add("error", NewErrorCondition("buh"))
 
-	eval, err := conditions.Eval(nil)
+	eval, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.Error(t, err.ToError(), "No error expected.")
 	assert.Equal(t, "buh", err.ToError().Error(), "Unexpected error message.")

--- a/internal/condition/deployment_config_condition.go
+++ b/internal/condition/deployment_config_condition.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	"github.com/sirupsen/logrus"
 )
 
 // DeploymentConfigCondition covers changes to DeploymentConfigs.
@@ -14,22 +15,34 @@ type DeploymentConfigCondition struct {
 
 // NewDCCondition creates a new instance of DeploymentConfigCondition.
 func NewDCCondition(idleAfter time.Duration) Condition {
-	b := &DeploymentConfigCondition{
+	return &DeploymentConfigCondition{
 		idleAfter: idleAfter,
 	}
-	return b
 }
 
 // Eval returns true if the last deployment config change occurred for more than the configured idle after interval.
 func (c *DeploymentConfigCondition) Eval(object interface{}) (bool, error) {
-	b, ok := object.(model.User)
+	u, ok := object.(model.User)
 	if !ok {
 		return false, fmt.Errorf("%T is not of type User", object)
 	}
 
-	if b.JenkinsLastUpdate.Add(c.idleAfter).Before(time.Now()) {
+	log := logrus.WithFields(logrus.Fields{
+		"id":        u.ID,
+		"name":      u.Name,
+		"component": "dc-condition",
+	})
+
+	if u.JenkinsLastUpdate.Add(c.idleAfter).Before(time.Now()) {
+		log.WithField("action", "idle").Infof(
+			"%v has elapsed after jenkins last update at %v",
+			c.idleAfter, u.JenkinsLastUpdate)
 		return true, nil
 	}
+
+	log.WithField("action", "unidle").Infof(
+		"%v has not elapsed after jenkins last update at %v",
+		c.idleAfter, u.JenkinsLastUpdate)
 
 	return false, nil
 }


### PR DESCRIPTION
This does not fix the issue rather only adds more logging to idler so
that we can analyse further why certain jenkins pods are not getting
idled or woken up.

With these logs added we get the following information
  - WARN  idler disabled for user <user> - skipping
  - ERROR No user info found for namespace <namespace>
  - INFO  Will send user <user> to Idler due to active build
  - INFO  Evaluating conditions for user <user>
  - INFO  active build started at <time> has gone past completion <time>  action=idle  component=build-condition
  - INFO  30m0s has elapsed after jenkins last update at <time>  action=idle component=dc-condition
  - INFO  conditions/idle: true = build=true | DC=true | user=true name=user-name component=condition