### PR TITLE
Remove unused WatchDeployment in openshift client

### DIFF
--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -27,7 +27,6 @@ type OpenShiftClient interface {
 	State(apiURL string, bearerToken string, namespace string, service string) (model.PodState, error)
 	WhoAmI(apiURL string, bearerToken string) (string, error)
 	WatchBuilds(apiURL string, bearerToken string, buildType string, callback func(model.Object) error) error
-	WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error
 	Reset(apiURL string, bearerToken string, namespace string) error
 }
 
@@ -341,72 +340,6 @@ func (o openShift) WatchBuilds(apiURL string, bearerToken string, buildType stri
 			}
 		}
 		logger.Debug("Fell out of loop for Build")
-	}
-}
-
-// WatchDeploymentConfigs consumes stream of DeploymentConfig events from openShift and calls callback to process them.
-func (o openShift) WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error {
-	// Use a HTTP client with disabled timeout.
-	c := &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost: 20,
-		},
-		Timeout: time.Duration(0) * time.Second,
-	}
-	for {
-		req, err := o.reqOAPIWatch(apiURL, bearerToken, "GET", "", "deploymentconfigs", nil)
-		if err != nil {
-			logger.Fatal(err)
-		}
-		v := req.URL.Query()
-		v.Add("labelSelector", "app=jenkins")
-		req.URL.RawQuery = v.Encode()
-		resp, err := c.Do(req)
-		if resp != nil && resp.StatusCode != http.StatusOK {
-			logger.Errorf("got status %s (%d) from %s", resp.Status, resp.StatusCode, req.URL)
-			continue
-		}
-		if err != nil {
-			logger.Errorf("Request failed: %s", err)
-			continue
-		}
-
-		reader := bufio.NewReader(resp.Body)
-		for {
-			line, err := reader.ReadBytes('\n')
-			if err != nil {
-				if err.Error() == "EOF" || err.Error() == "unexpected EOF" {
-					logger.Info("Got error ", err, " but continuing..")
-					break
-				}
-			}
-
-			o := model.DCObject{}
-
-			err = json.Unmarshal(line, &o)
-			if err != nil {
-				if strings.HasPrefix(string(line), "This request caused apisever to panic") {
-					logger.WithField("error", string(line)).Warning("Communication with server failed")
-					break
-				}
-				logger.Errorf("Failed to Unmarshal: %s", err)
-				break
-			}
-
-			// Filter for a given suffix.
-			if !strings.HasSuffix(o.Object.Metadata.Namespace, namespaceSuffix) {
-				logger.WithField("namespace", o.Object.Metadata.Namespace).Debug("Skipping DC change event")
-				continue
-			}
-
-			logger.WithFields(logrus.Fields{"namespace": o.Object.Metadata.Namespace, "data": o}).Debug("Handling DC change event")
-			err = callback(o)
-			if err != nil {
-				logger.Errorf("Error from DC callback: %s", err)
-				continue
-			}
-		}
-		logger.Debug("Fell out of loop for watching DC")
 	}
 }
 

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -68,15 +68,6 @@ func (c *OpenShiftClient) WatchBuilds(apiURL string, bearerToken string, buildTy
 	return nil
 }
 
-// WatchDeploymentConfigs mocks WatchDeploymentConfigs method of client.OpenShiftClient.
-// It always returns nil.
-func (c *OpenShiftClient) WatchDeploymentConfigs(apiURL string, bearerToken string, nsSuffix string, callback func(model.DCObject) error) error {
-	if c.IdleError != "" {
-		return fmt.Errorf(c.IdleError)
-	}
-	return nil
-}
-
 // ResetCounts resets calls made to the idler(idle/unidle) to 0.
 func (c *OpenShiftClient) ResetCounts() {
 	c.UnIdleCallCount = 0


### PR DESCRIPTION
Commit 268cd06f0028f95d376d98e24771c48f06d0249c didn't cleanup all
references to WatchDeploymentConfig.
