### PR TITLE
Handle dc change event

### DIFF
--- a/cmd/fabric8-jenkins-idler/idler.go
+++ b/cmd/fabric8-jenkins-idler/idler.go
@@ -115,12 +115,29 @@ func (idler *Idler) watchOpenshiftEvents(t *task, userIdlers *openshift.UserIdle
 			t.cancel,
 		)
 
-		t.wg.Add(1)
+		t.wg.Add(2)
+		go idler.watchDC(t, oc, c, ctrl.HandleDeploymentConfig)
 		go idler.watchBC(t, oc, c, ctrl.HandleBuild)
 	}
 }
 
+type dcHandler func(model.DCObject) error
 type bcHandler func(model.Object) error
+
+func (idler *Idler) watchDC(t *task, oc client.OpenShiftClient, c cluster.Cluster, handler dcHandler) {
+	defer t.wg.Done()
+	go func() {
+		idlerLogger.Info("Starting to watch openshift deployment configuration changes.")
+		err := oc.WatchDeploymentConfigs(c.APIURL, c.Token, "-jenkins", handler)
+		if err != nil {
+			t.cancel()
+		}
+	}()
+
+	<-t.ctx.Done()
+	idlerLogger.Infof("Stopping to watch openshift deployment configuration changes.")
+	t.cancel()
+}
 
 func (idler *Idler) watchBC(t *task, oc client.OpenShiftClient, c cluster.Cluster, handler bcHandler) {
 	defer t.wg.Done()

--- a/cmd/fabric8-jenkins-idler/idler_test.go
+++ b/cmd/fabric8-jenkins-idler/idler_test.go
@@ -56,6 +56,7 @@ func Test_graceful_shutdown(t *testing.T) {
 
 	logMessages := extractLogMessages(hook.AllEntries())
 	assert.Contains(t, logMessages, "Stopping to watch openshift build configuration changes.", "Idler shutdown completion should have been logged")
+	assert.Contains(t, logMessages, "Stopping to watch openshift deployment configuration changes.", "Idler shutdown completion should have been logged")
 	assert.Contains(t, logMessages, "Idler successfully shut down.", "Idler shutdown completion should have been logged")
 }
 

--- a/internal/condition/build_condition.go
+++ b/internal/condition/build_condition.go
@@ -23,10 +23,10 @@ func NewBuildCondition(idleAfter time.Duration, idleLongBuild time.Duration) Con
 
 // Eval returns true if the passed User does not have any builds or does not have any
 // active builds and the time elapsed since the last completed build is created than the configured idle after time.
-func (c *BuildCondition) Eval(object interface{}) (bool, error) {
+func (c *BuildCondition) Eval(object interface{}) (Action, error) {
 	u, ok := object.(model.User)
 	if !ok {
-		return false, fmt.Errorf("%T is not of type User", object)
+		return NoAction, fmt.Errorf("%T is not of type User", object)
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -35,46 +35,70 @@ func (c *BuildCondition) Eval(object interface{}) (bool, error) {
 		"component": "build-condition",
 	})
 
+	log.WithField("check", "any-builds").Infof("Checking if there are any builds")
+	if !u.HasBuilds() {
+		log.WithField("action", "idle").Infof("user has no builds")
+		return Idle, nil
+	}
+
+	now := time.Now().UTC()
+
+	log.WithField("check", "active-builds").Infof("Checking active builds")
 	if u.HasActiveBuilds() {
 		// if we have activebuild being active over x time then see it as
 		// expired or they would be lingering forever (i.e: approval process pipelines)
+
 		startTime := u.ActiveBuild.Status.StartTimestamp.Time
-		if startTime.Add(c.idleLongBuild).Before(time.Now()) {
+		maxBuildTime := startTime.Add(c.idleLongBuild)
+		log.WithField("check", "active-build-timedout").Infof(
+			"has active build started at %v has exceeded max build time: %v ", startTime, maxBuildTime)
+
+		if now.After(maxBuildTime) {
 			log.WithField("action", "idle").Infof(
-				"active build started at %v has exceeded timeout %v",
-				startTime, c.idleLongBuild)
-			return true, nil
+				"active build started at %v has exceeded timeout %v", startTime, c.idleLongBuild)
+			return Idle, nil
 		}
 
 		completionTime := u.ActiveBuild.Status.CompletionTimestamp.Time
+
+		log.WithField("check", "active-build-completed").Infof(
+			"has active build started at %v gone past completion time %v", startTime, completionTime)
 		if u.ActiveBuild.Status.Phase == "New" &&
-			startTime.Add(time.Second*5).After(completionTime) {
+			completionTime.Sub(startTime) > 2*time.Second {
 			log.WithField("action", "idle").Infof(
 				"active build started at %v has gone past completion time %v",
 				startTime, completionTime)
-			return true, nil
+			/// TODO: not sure about this
+			return Idle, nil
 		}
 
 		log.WithField("action", "unidle").Infof(
 			"active build started at %v seems to be in progress", startTime)
-		return false, nil
+		return UnIdle, nil
 	}
 
-	if !u.HasBuilds() {
-		log.WithField("action", "idle").Infof("user has no builds")
-		return true, nil
+	// Done builds
+
+	log.WithField("check", "done-builds").Infof("Checking done builds")
+
+	if u.DoneBuild.Status.Phase == "Cancelled" {
+		log.WithField("action", "idle").Infof("Build is cancelled")
+		return Idle, nil
 	}
 
 	completionTime := u.DoneBuild.Status.CompletionTimestamp.Time
-	if completionTime.Add(c.idleAfter).Before(time.Now()) {
+	terminateTime := completionTime.Add(c.idleAfter)
+
+	log.WithField("check", "done-builds").Infof(
+		"Check if completion time %v is past terminate time: %v", now, terminateTime)
+
+	if now.After(terminateTime) {
 		log.WithField("action", "idle").Infof(
-			"%v has elapsed after last done-build at %v ",
-			c.idleAfter, completionTime)
-		return true, nil
+			"%v has elapsed after last done-build at %v ", c.idleAfter, completionTime)
+		return Idle, nil
 	}
 
-	log.WithField("action", "unidle").Infof(
-		"%v has not yet elapsed after last done-build at %v ",
-		c.idleAfter, completionTime)
-	return false, nil
+	log.WithField("action", "none").Infof(
+		"%v has not yet elapsed after last done-build at %v ", c.idleAfter, completionTime)
+	return NoAction, nil
 }

--- a/internal/condition/build_condition_test.go
+++ b/internal/condition/build_condition_test.go
@@ -20,7 +20,7 @@ func Test_eval_idle_if_there_are_no_builds(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Condition should evaluate to Idle.")
 }
 
 func Test_eval_unidle_when_active_build_exists(t *testing.T) {
@@ -36,7 +36,7 @@ func Test_eval_unidle_when_active_build_exists(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(UnIdle), result, "Condition should evaluate to UnIdle.")
+	assert.Equal(t, UnIdle, result, "Condition should evaluate to UnIdle.")
 }
 
 func Test_eval_idle_when_activebuild_is_old(t *testing.T) {
@@ -55,7 +55,7 @@ func Test_eval_idle_when_activebuild_is_old(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(10)*time.Hour)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Condition should evaluate to Idle.")
 }
 
 func Test_eval_completion_before_idletime_expires(t *testing.T) {
@@ -71,7 +71,7 @@ func Test_eval_completion_before_idletime_expires(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(NoAction), result, "Condition should evaluate to UnIdle.")
+	assert.Equal(t, NoAction, result, "Condition should evaluate to UnIdle.")
 }
 
 func Test_eval_completion_after_idletime_expires(t *testing.T) {
@@ -91,7 +91,7 @@ func Test_eval_completion_after_idletime_expires(t *testing.T) {
 	condition := NewBuildCondition(5*time.Minute, 5*time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Condition should evaluate to Idle.")
 }
 
 func Test_eval_ignore_pesky_jenkins_sync_plugin(t *testing.T) {
@@ -111,5 +111,5 @@ func Test_eval_ignore_pesky_jenkins_sync_plugin(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(10)*time.Hour)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Condition should evaluate to Idle.")
 }

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -17,12 +17,12 @@ const (
 	// NoAction  an unknown state of the Pod. Used usually with Error.
 	NoAction Action = 0
 	// Idle represents the idled state of a Pod.
-	Idle = 1
+	Idle Action = 1
 	// UnIdle state is when Pods are about to start.
-	UnIdle = 2
+	UnIdle Action = 2
 
 	// unknownAction used internally for range check
-	unknownAction = 3
+	unknownAction Action = 3
 )
 
 func (a Action) String() string {

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -9,10 +9,38 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Action is a tri-state enum for  different actions to be applied to Pod.
+// E.g. Pods can be Idled, UnIdled or Left at its current state.
+type Action int
+
+const (
+	// NoAction  an unknown state of the Pod. Used usually with Error.
+	NoAction Action = 0
+	// Idle represents the idled state of a Pod.
+	Idle = 1
+	// UnIdle state is when Pods are about to start.
+	UnIdle = 2
+
+	// unknownAction used internally for range check
+	unknownAction = 3
+)
+
+func (a Action) String() string {
+	actions := [...]string{
+		"no action",
+		"idle",
+		"unidle",
+	}
+	if a < NoAction || a >= unknownAction {
+		return "unknown action"
+	}
+	return actions[a]
+}
+
 // Condition defines a single Eval method which returns true or false.
 type Condition interface {
 	// Return true if the condition is true for a given object.
-	Eval(object interface{}) (bool, error)
+	Eval(object interface{}) (Action, error)
 }
 
 // Conditions defines map of Condition instances by their names
@@ -29,13 +57,13 @@ func NewConditions() Conditions {
 
 // Eval evaluates a list of Conditions for a given object. It returns false if
 // any of the conditions evaluates to false, otherwise true.
-func (c *Conditions) Eval(o interface{}) (bool, util.MultiError) {
+func (c *Conditions) Eval(o interface{}) (Action, util.MultiError) {
 	errors := util.MultiError{}
 
 	u, ok := o.(model.User)
 	if !ok {
 		errors.Collect(fmt.Errorf("%T is not of type User", o))
-		return false, errors
+		return NoAction, errors
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -44,21 +72,28 @@ func (c *Conditions) Eval(o interface{}) (bool, util.MultiError) {
 		"component": "condition",
 	})
 
-	result := true
-	condStates := make(map[string]bool)
+	condStates := make(map[string]Action)
+
+	result := NoAction
 	for name, ci := range c.conditions {
-		r, err := ci.Eval(o)
+		action, err := ci.Eval(o)
+
 		if err != nil {
 			log.Error(err)
 			errors.Collect(err)
 		}
-		if !r {
-			result = false
+
+		condStates[name] = action
+
+		// overall result is the max of all conditions
+		if action > result {
+			result = action
 		}
-		condStates[name] = r
+		// TODO(sthaha): skip rest of the condition check is any of the
+		// condition results in UnIdle
 	}
 
-	log.Infof("conditions/idle: %t = %s", result, c.conditionMapToString(condStates))
+	log.Infof("conditions/result: %s | %s", result, c.conditionMapToString(condStates))
 	return result, errors
 }
 
@@ -67,10 +102,10 @@ func (c *Conditions) Add(name string, condition Condition) {
 	c.conditions[name] = condition
 }
 
-func (c *Conditions) conditionMapToString(conditions map[string]bool) string {
+func (c *Conditions) conditionMapToString(conditions map[string]Action) string {
 	var result []string
 	for key, value := range conditions {
-		result = append(result, fmt.Sprintf("%s=%t", key, value))
+		result = append(result, fmt.Sprintf("%s: %s", key, value))
 	}
 	return strings.Join(result, " | ")
 }

--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -46,7 +46,7 @@ func Test_all_conditions_idle(t *testing.T) {
 	result, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
-	assert.Equal(t, Action(Idle), result, "Should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Should evaluate to Idle.")
 }
 
 func Test_all_conditions_unidle(t *testing.T) {
@@ -58,7 +58,7 @@ func Test_all_conditions_unidle(t *testing.T) {
 	result, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
-	assert.Equal(t, Action(UnIdle), result, "Should evaluate to unidle")
+	assert.Equal(t, UnIdle, result, "Should evaluate to unidle")
 }
 
 func Test_mixed_conditions(t *testing.T) {
@@ -70,7 +70,7 @@ func Test_mixed_conditions(t *testing.T) {
 	result, err := conditions.Eval(model.NewUser("id", "name"))
 
 	assert.NoError(t, err.ToError(), "No error expected.")
-	assert.Equal(t, Action(UnIdle), result, "Should evaluate to UnIdle.")
+	assert.Equal(t, UnIdle, result, "Should evaluate to UnIdle.")
 }
 
 func Test_error_conditions(t *testing.T) {
@@ -84,5 +84,5 @@ func Test_error_conditions(t *testing.T) {
 
 	assert.Error(t, err.ToError(), "No error expected.")
 	assert.Equal(t, "buh", err.ToError().Error(), "Unexpected error message.")
-	assert.Equal(t, Action(Idle), result, "Should evaluate to false.")
+	assert.Equal(t, Idle, result, "Should evaluate to false.")
 }

--- a/internal/condition/deployment_config_condition.go
+++ b/internal/condition/deployment_config_condition.go
@@ -1,0 +1,48 @@
+package condition
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	"github.com/sirupsen/logrus"
+)
+
+// DeploymentConfigCondition covers changes to DeploymentConfigs.
+type DeploymentConfigCondition struct {
+	idleAfter time.Duration
+}
+
+// NewDCCondition creates a new instance of DeploymentConfigCondition.
+func NewDCCondition(idleAfter time.Duration) Condition {
+	return &DeploymentConfigCondition{
+		idleAfter: idleAfter,
+	}
+}
+
+// Eval returns true if the last deployment config change occurred for more than the configured idle after interval.
+func (c *DeploymentConfigCondition) Eval(object interface{}) (bool, error) {
+	u, ok := object.(model.User)
+	if !ok {
+		return false, fmt.Errorf("%T is not of type User", object)
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"id":        u.ID,
+		"name":      u.Name,
+		"component": "dc-condition",
+	})
+
+	if u.JenkinsLastUpdate.Add(c.idleAfter).Before(time.Now()) {
+		log.WithField("action", "idle").Infof(
+			"%v has elapsed after jenkins last update at %v",
+			c.idleAfter, u.JenkinsLastUpdate)
+		return true, nil
+	}
+
+	log.WithField("action", "unidle").Infof(
+		"%v has not elapsed after jenkins last update at %v",
+		c.idleAfter, u.JenkinsLastUpdate)
+
+	return false, nil
+}

--- a/internal/condition/deployment_config_condition_test.go
+++ b/internal/condition/deployment_config_condition_test.go
@@ -1,0 +1,33 @@
+package condition
+
+import (
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_non_user_creates_error_in_build_condition(t *testing.T) {
+	user := "foo"
+	condition := NewDCCondition(time.Duration(5) * time.Minute)
+	_, err := condition.Eval(user)
+	assert.Error(t, err, "Passing non User instances to Eval should return an error.")
+}
+
+func Test_eval_returns_true_for_deployment_config_condition_if_last_change_is_older_than_idle_time(t *testing.T) {
+	user := model.NewUser("123", "foo")
+	user.JenkinsLastUpdate = time.Now().Add(-6 * time.Minute)
+	condition := NewDCCondition(time.Duration(5) * time.Minute)
+	condValue, err := condition.Eval(user)
+	assert.NoError(t, err)
+	assert.True(t, condValue, "Condition should evaluate to true.")
+}
+
+func Test_eval_returns_false_for_deployment_config_condition_if_last_change_is_younger_than_idle_time(t *testing.T) {
+	user := model.NewUser("123", "foo")
+	user.JenkinsLastUpdate = time.Now().Add(-4 * time.Minute)
+	condition := NewDCCondition(time.Duration(5) * time.Minute)
+	condValue, err := condition.Eval(user)
+	assert.NoError(t, err)
+	assert.False(t, condValue, "Condition should evaluate to false.")
+}

--- a/internal/condition/deployment_config_condition_test.go
+++ b/internal/condition/deployment_config_condition_test.go
@@ -21,7 +21,7 @@ func Test_eval_idle_for_deployment_config_condition_if_last_change_is_older_than
 	condition := NewDCCondition(time.Duration(5) * time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
+	assert.Equal(t, Idle, result, "Condition should evaluate to Idle.")
 }
 
 func Test_eval_unidle_for_deployment_config_condition_if_last_change_is_younger_than_g_time(t *testing.T) {
@@ -30,5 +30,5 @@ func Test_eval_unidle_for_deployment_config_condition_if_last_change_is_younger_
 	condition := NewDCCondition(time.Duration(5) * time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, Action(UnIdle), result, "Condition should evaluate to UnIdle")
+	assert.Equal(t, UnIdle, result, "Condition should evaluate to UnIdle")
 }

--- a/internal/condition/deployment_config_condition_test.go
+++ b/internal/condition/deployment_config_condition_test.go
@@ -1,10 +1,11 @@
 package condition
 
 import (
-	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_non_user_creates_error_in_build_condition(t *testing.T) {
@@ -14,20 +15,20 @@ func Test_non_user_creates_error_in_build_condition(t *testing.T) {
 	assert.Error(t, err, "Passing non User instances to Eval should return an error.")
 }
 
-func Test_eval_returns_true_for_deployment_config_condition_if_last_change_is_older_than_idle_time(t *testing.T) {
+func Test_eval_idle_for_deployment_config_condition_if_last_change_is_older_than_g_time(t *testing.T) {
 	user := model.NewUser("123", "foo")
 	user.JenkinsLastUpdate = time.Now().Add(-6 * time.Minute)
 	condition := NewDCCondition(time.Duration(5) * time.Minute)
-	condValue, err := condition.Eval(user)
+	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.True(t, condValue, "Condition should evaluate to true.")
+	assert.Equal(t, Action(Idle), result, "Condition should evaluate to Idle.")
 }
 
-func Test_eval_returns_false_for_deployment_config_condition_if_last_change_is_younger_than_idle_time(t *testing.T) {
+func Test_eval_unidle_for_deployment_config_condition_if_last_change_is_younger_than_g_time(t *testing.T) {
 	user := model.NewUser("123", "foo")
 	user.JenkinsLastUpdate = time.Now().Add(-4 * time.Minute)
 	condition := NewDCCondition(time.Duration(5) * time.Minute)
-	condValue, err := condition.Eval(user)
+	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.False(t, condValue, "Condition should evaluate to false.")
+	assert.Equal(t, Action(UnIdle), result, "Condition should evaluate to UnIdle")
 }

--- a/internal/condition/user_condition.go
+++ b/internal/condition/user_condition.go
@@ -1,0 +1,92 @@
+package condition
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/model"
+	log "github.com/sirupsen/logrus"
+)
+
+var logger = log.WithFields(log.Fields{"component": "user-condition"})
+
+// ProxyResponse represents response provided by the Jenkins Proxy for a particular user.
+type ProxyResponse struct {
+	Namespace   string `json:"namespace"`
+	Requests    int    `json:"requests"`
+	LastVisit   int64  `json:"last_visit"`
+	LastRequest int64  `json:"last_request"`
+}
+
+// UserCondition covers information about User as provided by the Jenkins Proxy.
+type UserCondition struct {
+	idleAfter time.Duration
+	proxyURL  string
+}
+
+// NewUserCondition creates a new instance of Condition given a proxyURL and idleAfter.
+func NewUserCondition(proxyURL string, idleAfter time.Duration) Condition {
+	b := &UserCondition{
+		proxyURL:  proxyURL,
+		idleAfter: idleAfter,
+	}
+	return b
+}
+
+// Eval returns true if there are no buffered request, the last forwarded request occurred more than UserCondition.idleAfter
+// minutes ago and the user accessed the Jenkins UI more than UserCondition.idleAfter minutes ago.
+func (c *UserCondition) Eval(object interface{}) (bool, error) {
+	b, ok := object.(model.User)
+	if !ok {
+		return false, fmt.Errorf("%s is not of type User", object)
+	}
+
+	proxyResponse, err := c.getProxyResponse(b.Name)
+	if err != nil {
+		return false, err
+	}
+
+	if proxyResponse.Requests > 0 {
+		return false, nil
+	}
+
+	tu := time.Unix(proxyResponse.LastVisit, 0)
+	tr := time.Unix(proxyResponse.LastRequest, 0)
+	if tu.Add(c.idleAfter).Before(time.Now()) && tr.Add(c.idleAfter).Before(time.Now()) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *UserCondition) getProxyResponse(userName string) (*ProxyResponse, error) {
+	url := fmt.Sprintf("%s/api/info/%s-jenkins", c.proxyURL, userName)
+	logger.WithField("url", url).Debug("Accessing Proxy API.")
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		logger.Error(fmt.Sprintf("Got status %s fom %s", resp.Status, url))
+		return nil, errors.New(resp.Status)
+	}
+
+	proxyResponse := ProxyResponse{}
+	err = json.Unmarshal(body, &proxyResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &proxyResponse, err
+}

--- a/internal/condition/user_condition_test.go
+++ b/internal/condition/user_condition_test.go
@@ -1,0 +1,30 @@
+package condition
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-jenkins-idler/internal/testutils/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_get_proxy_response(t *testing.T) {
+	// TODO(chmouel): Need to get the actual response from the proxy, built this
+	// json from reading proxy code.
+	tenantData, err := ioutil.ReadFile("../testutils/testdata/proxy.json")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	srv := common.MockServer(tenantData)
+	defer srv.Close()
+
+	uc := UserCondition{
+		proxyURL: srv.URL,
+	}
+
+	response, err := uc.getProxyResponse("test")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, "test", response.Namespace)
+}

--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -304,5 +304,14 @@ func createWatchConditions(proxyURL string, idleAfter int, idleLongBuild int, lo
 		time.Duration(idleAfter)*time.Minute,
 		time.Duration(idleLongBuild)*time.Hour))
 
+	// Add a DeploymentConfig condition.
+	conditions.Add("DC", condition.NewDCCondition(time.Duration(idleAfter)*time.Minute))
+
+	// If we have access to Proxy, add User condition.
+	if len(proxyURL) > 0 {
+		logEntry.Debug("Adding 'user' condition")
+		conditions.Add("user", condition.NewUserCondition(proxyURL, time.Duration(idleAfter)*time.Minute))
+	}
+
 	return &conditions
 }

--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -226,7 +226,7 @@ func (idler *UserIdler) doIdle() error {
 
 		err := idler.openShiftClient.Idle(idler.openShiftAPI, idler.openShiftBearerToken, idler.user.Name+jenkinsNamespaceSuffix, service)
 		if err != nil {
-			log.Error("Idling of %s returned error:  %s ", service, err)
+			log.Errorf("Idling of %s returned error:  %s", service, err)
 			return err
 		}
 		log.Infof("sucessfully idled %s", service)

--- a/internal/idler/user_idler_test.go
+++ b/internal/idler/user_idler_test.go
@@ -19,15 +19,15 @@ import (
 type ErrorCondition struct {
 }
 
-func (c *ErrorCondition) Eval(object interface{}) (bool, error) {
-	return false, errors.New("eval error")
+func (c *ErrorCondition) Eval(object interface{}) (condition.Action, error) {
+	return condition.NoAction, errors.New("eval error")
 }
 
 type UnIdleCondition struct {
 }
 
-func (c *UnIdleCondition) Eval(object interface{}) (bool, error) {
-	return false, nil
+func (c *UnIdleCondition) Eval(object interface{}) (condition.Action, error) {
+	return condition.UnIdle, nil
 }
 
 func Test_idle_check_skipped_if_feature_not_enabled(t *testing.T) {

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -94,6 +94,9 @@ func (u *User) HasBuilds() bool {
 	return u.HasActiveBuilds() || u.HasCompletedBuilds()
 }
 
-func (u *User) String() string {
-	return fmt.Sprintf("HasBuilds:%t HasActiveBuilds:%t JenkinsLastUpdate:%v", u.HasBuilds(), u.HasActiveBuilds(), u.JenkinsLastUpdate.Format(time.RFC822))
+// StateDump returns a String representing the internal states like
+// HasActiveBuilds, LastUpdate etc useful for debugging
+func (u *User) StateDump() string {
+	return fmt.Sprintf("HasBuilds:%t HasActiveBuilds:%t JenkinsLastUpdate:%v",
+		u.HasBuilds(), u.HasActiveBuilds(), u.JenkinsLastUpdate.Format(time.RFC822))
 }

--- a/internal/model/user_test.go
+++ b/internal/model/user_test.go
@@ -2,13 +2,14 @@ package model
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_String(t *testing.T) {
 	user := User{ID: "42"}
-	userAsString := user.String()
+	userAsString := user.StateDump()
 
 	assert.Equal(t, userAsString, "HasBuilds:false HasActiveBuilds:false JenkinsLastUpdate:01 Jan 01 00:00 UTC", "Unexpected string format")
 }

--- a/internal/openshift/client/openshift_client.go
+++ b/internal/openshift/client/openshift_client.go
@@ -27,6 +27,7 @@ type OpenShiftClient interface {
 	State(apiURL string, bearerToken string, namespace string, service string) (model.PodState, error)
 	WhoAmI(apiURL string, bearerToken string) (string, error)
 	WatchBuilds(apiURL string, bearerToken string, buildType string, callback func(model.Object) error) error
+	WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error
 	Reset(apiURL string, bearerToken string, namespace string) error
 }
 
@@ -340,6 +341,72 @@ func (o openShift) WatchBuilds(apiURL string, bearerToken string, buildType stri
 			}
 		}
 		logger.Debug("Fell out of loop for Build")
+	}
+}
+
+// WatchDeploymentConfigs consumes stream of DeploymentConfig events from openShift and calls callback to process them.
+func (o openShift) WatchDeploymentConfigs(apiURL string, bearerToken string, namespaceSuffix string, callback func(model.DCObject) error) error {
+	// Use a HTTP client with disabled timeout.
+	c := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: 20,
+		},
+		Timeout: time.Duration(0) * time.Second,
+	}
+	for {
+		req, err := o.reqOAPIWatch(apiURL, bearerToken, "GET", "", "deploymentconfigs", nil)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		v := req.URL.Query()
+		v.Add("labelSelector", "app=jenkins")
+		req.URL.RawQuery = v.Encode()
+		resp, err := c.Do(req)
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			logger.Errorf("got status %s (%d) from %s", resp.Status, resp.StatusCode, req.URL)
+			continue
+		}
+		if err != nil {
+			logger.Errorf("Request failed: %s", err)
+			continue
+		}
+
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				if err.Error() == "EOF" || err.Error() == "unexpected EOF" {
+					logger.Info("Got error ", err, " but continuing..")
+					break
+				}
+			}
+
+			o := model.DCObject{}
+
+			err = json.Unmarshal(line, &o)
+			if err != nil {
+				if strings.HasPrefix(string(line), "This request caused apisever to panic") {
+					logger.WithField("error", string(line)).Warning("Communication with server failed")
+					break
+				}
+				logger.Errorf("Failed to Unmarshal: %s", err)
+				break
+			}
+
+			// Filter for a given suffix.
+			if !strings.HasSuffix(o.Object.Metadata.Namespace, namespaceSuffix) {
+				logger.WithField("namespace", o.Object.Metadata.Namespace).Debug("Skipping DC change event")
+				continue
+			}
+
+			logger.WithFields(logrus.Fields{"namespace": o.Object.Metadata.Namespace, "data": o}).Debug("Handling DC change event")
+			err = callback(o)
+			if err != nil {
+				logger.Errorf("Error from DC callback: %s", err)
+				continue
+			}
+		}
+		logger.Debug("Fell out of loop for watching DC")
 	}
 }
 

--- a/internal/openshift/controller.go
+++ b/internal/openshift/controller.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"context"
@@ -26,10 +27,11 @@ var logger = logrus.WithFields(logrus.Fields{"component": "controller"})
 // Controller defines the interface for watching the openShift cluster for changes.
 type Controller interface {
 	HandleBuild(o model.Object) error
+	HandleDeploymentConfig(dc model.DCObject) error
 }
 
-// controllerImpl watches a single OpenShift cluster for Build changes.
-// This struct needs to be safe for concurrent use.
+// controllerImpl watches a single OpenShift cluster for Build and Deployment Config changes. This struct needs to be
+// safe for concurrent use.
 type controllerImpl struct {
 	openshiftURL  string
 	osBearerToken string
@@ -91,6 +93,11 @@ func (c *controllerImpl) HandleBuild(o model.Object) error {
 	}
 
 	if !ok {
+		// We can have a situation where a single OpenShift cluster is used by prod
+		// as well as prod-preview. We see events from tenants of both clusters
+		// which means in some cases we won't get tenant information
+		// See: https://github.com/fabric8-services/fabric8-jenkins-idler/issues/155
+		log.Errorf("No user info found for namespace %q", ns)
 		return nil
 	}
 
@@ -144,18 +151,92 @@ func (c *controllerImpl) HandleBuild(o model.Object) error {
 	return nil
 }
 
+// HandleDeploymentConfig processes new DC event collected from openShift and updates
+// user structure with info about the changes in DC. NOTE: This is important for cases
+// like reset tenantService and update tenantService when DC is updated and Jenkins starts because
+// of ConfigChange or manual intervention.
+func (c *controllerImpl) HandleDeploymentConfig(dc model.DCObject) error {
+	ns := dc.Object.Metadata.Namespace[:len(dc.Object.Metadata.Namespace)-len(jenkinsNamespaceSuffix)]
+
+	log := logger.WithFields(logrus.Fields{
+		"event":     "dc",
+		"openshift": c.openshiftURL,
+		"ns":        ns,
+	})
+
+	ok, err := c.createIfNotExist(ns)
+	if err != nil {
+		log.Errorf("Creating user-idler record failed: %s", err)
+		return err
+	}
+
+	if !ok {
+		// We can have a situation where a single OpenShift cluster is used by prod as well as prod-preview
+		// For now we see in this case events from tenants of both clusters which means in some cases
+		// we won't get tenant information
+		// See also https://github.com/fabric8-services/fabric8-jenkins-idler/issues/155
+		log.Errorf("No user info found for namespace %q", ns)
+		return nil
+	}
+
+	userIdler := c.userIdlerForNamespace(ns)
+	user := userIdler.GetUser()
+
+	log = log.WithFields(logrus.Fields{
+		"id":   user.ID,
+		"name": user.Name,
+	})
+
+	evalConditions := false
+	condition, err := dc.Object.Status.GetByType(availableCond)
+	if err != nil {
+		log.Errorf("Available condition not present (%s) in the list of conditions - SKIPPING", err)
+		// stop processing since the pod isn't available yet
+		return nil
+	}
+
+	// TODO Verify if we need Generation vs. ObservedGeneration
+	// This is either a new version of DC or we existing version waiting to come up.
+	if (dc.Object.Metadata.Generation != dc.Object.Status.ObservedGeneration && dc.Object.Spec.Replicas > 0) ||
+		dc.Object.Status.UnavailableReplicas > 0 {
+
+		user.JenkinsLastUpdate = time.Now().UTC()
+		evalConditions = true
+		log.Infof("Will send user %v to Idler due to a new version of DC or an existing version is coming up", user.Name)
+	}
+
+	// Also check if the event means that Jenkins just started (OS AvailableCondition.Status == true) and update time.
+	status, err := strconv.ParseBool(condition.Status)
+	if err != nil {
+		return err
+	}
+
+	if status == true {
+		user.JenkinsLastUpdate = condition.LastUpdateTime
+		evalConditions = true
+		log.Infof("Will send user %v to Idler because Jenkins was just started", user.Name)
+	}
+
+	if evalConditions {
+		log.Infof("Sending user %v to Idler due a Deployment Config event", user.Name)
+		sendUserToIdler(userIdler, user)
+	}
+
+	return nil
+}
+
 // createIfNotExist checks existence of a user in the map, initialise if it does not exist.
 func (c *controllerImpl) createIfNotExist(ns string) (bool, error) {
 
 	log := logger.WithField("ns", ns)
-	if _, exist := c.unknownUsers.Load(ns); exist {
-		log.Debugf("namespace %s listed in unknown users list", ns)
-		return false, nil
-	}
-
 	if _, exist := c.userIdlers.Load(ns); exist {
 		log.Debug("User idler found in cache")
 		return true, nil
+	}
+
+	if _, exist := c.unknownUsers.Load(ns); exist {
+		log.Debugf("namespace %s listed in unknown users list", ns)
+		return false, nil
 	}
 
 	log.Infof("creating user-idler for cluster %s", c.openshiftURL)
@@ -168,15 +249,7 @@ func (c *controllerImpl) createIfNotExist(ns string) (bool, error) {
 	if ti.Meta.TotalCount > 1 {
 		return false, fmt.Errorf("could not add new user - Tenant service returned multiple items: %d", ti.Meta.TotalCount)
 	} else if len(ti.Data) == 0 {
-
-		// We can have a situation where a single OpenShift cluster is used by prod
-		// as well as prod-preview and tenant service we connect to would only have
-		// details about prod or prod-preview but we see events from tenants of both
-		// prod and prod-preview which means in some cases we won't get tenant information
-		// See: https://github.com/fabric8-services/fabric8-jenkins-idler/issues/155
-
-		log.Debugf("No user info found for namespace %q", ns)
-		log.Debugf("adding namespace: %s to unknown users list namespace", ns)
+		log.Warnf("adding namespace: %s to unknown users list namespace", ns)
 		c.unknownUsers.Store(ns, nil)
 		return false, nil
 	}

--- a/internal/openshift/controller_test.go
+++ b/internal/openshift/controller_test.go
@@ -97,6 +97,11 @@ func TestHandleBuildChannelLength(t *testing.T) {
 		ci := controller.(*controllerImpl)
 		userIdler := ci.userIdlerForNamespace(ns)
 
+		if userIdler == nil {
+			t.Errorf("expected user-idler to be created")
+			return
+		}
+
 		userChannel := userIdler.GetChannel()
 		if test.channelLength != len(userChannel) {
 			t.Errorf("Expected channel length to be %v, but got %v", test.channelLength, len(userChannel))
@@ -174,6 +179,12 @@ func TestHandleDeploymentConfigChannelLength(t *testing.T) {
 		ns := test.object.Object.Metadata.Namespace[:len(test.object.Object.Metadata.Namespace)-len(jenkinsNamespaceSuffix)]
 		ci := controller.(*controllerImpl)
 		userIdler := ci.userIdlerForNamespace(ns)
+
+		if userIdler == nil {
+			t.Errorf("Expected user-idler to be created")
+			return
+		}
+
 		userChannel := userIdler.GetChannel()
 		if test.channelLength != len(userChannel) {
 			t.Errorf("Expected channel length to be %v, but got %v", test.channelLength, len(userChannel))

--- a/internal/openshift/controller_test.go
+++ b/internal/openshift/controller_test.go
@@ -105,6 +105,83 @@ func TestHandleBuildChannelLength(t *testing.T) {
 	}
 }
 
+func Test_handle_deployment_config(t *testing.T) {
+	setUp(t)
+	defer tearDown()
+
+	obj := model.DCObject{
+		Object: model.DeploymentConfig{
+			Metadata: model.Metadata{
+				Namespace: "test-namespace-jenkins",
+			},
+			Status: model.DCStatus{
+				Conditions: []model.Condition{
+					{
+						Type:   "Available",
+						Status: "false",
+					},
+				},
+			},
+		},
+		Type: "MODIFIED",
+	}
+
+	err := controller.HandleDeploymentConfig(obj)
+	assert.NoError(t, err)
+}
+
+func TestHandleDeploymentConfigChannelLength(t *testing.T) {
+	setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name          string
+		object        model.DCObject
+		channelLength int
+	}{
+		{
+			name: "both new DC and available condition is true, length should still be 1",
+			object: model.DCObject{
+				Object: model.DeploymentConfig{
+					Metadata: model.Metadata{
+						Namespace:  "test-namespace-jenkins",
+						Generation: 1,
+					},
+					Spec: model.Spec{
+						Replicas: 1,
+					},
+					Status: model.DCStatus{
+						ObservedGeneration: 2,
+						Conditions: []model.Condition{
+							{
+								Type:   availableCond,
+								Status: "true",
+							},
+						},
+					},
+				},
+			},
+			channelLength: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test: %v", test.name)
+
+		err := controller.HandleDeploymentConfig(test.object)
+		assert.NoError(t, err)
+
+		ns := test.object.Object.Metadata.Namespace[:len(test.object.Object.Metadata.Namespace)-len(jenkinsNamespaceSuffix)]
+		ci := controller.(*controllerImpl)
+		userIdler := ci.userIdlerForNamespace(ns)
+		userChannel := userIdler.GetChannel()
+		if test.channelLength != len(userChannel) {
+			t.Errorf("Expected channel length to be %v, but got %v", test.channelLength, len(userChannel))
+		}
+		emptyChannel(userChannel)
+	}
+}
+
 func setUp(t *testing.T) {
 	origWriter = log.StandardLogger().Out
 	log.SetOutput(ioutil.Discard)

--- a/internal/testutils/mock/mock_openshift_client.go
+++ b/internal/testutils/mock/mock_openshift_client.go
@@ -68,6 +68,15 @@ func (c *OpenShiftClient) WatchBuilds(apiURL string, bearerToken string, buildTy
 	return nil
 }
 
+// WatchDeploymentConfigs mocks WatchDeploymentConfigs method of client.OpenShiftClient.
+// It always returns nil.
+func (c *OpenShiftClient) WatchDeploymentConfigs(apiURL string, bearerToken string, nsSuffix string, callback func(model.DCObject) error) error {
+	if c.IdleError != "" {
+		return fmt.Errorf(c.IdleError)
+	}
+	return nil
+}
+
 // ResetCounts resets calls made to the idler(idle/unidle) to 0.
 func (c *OpenShiftClient) ResetCounts() {
 	c.UnIdleCallCount = 0


### PR DESCRIPTION
- Reverts: Remove DC watch patch 
- Reverts: Remove `user-condition`  patch 
- Fixes HandleDC change in `controller` to not Update `JenkinsLastUpdate ` to Now so that Jenkins can be idled soon after tenant-update
- Adds a NoAction as one of the Condition resutls. 