### PR TITLE
Disable user condition due to response errors

### DIFF
--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -349,11 +349,5 @@ func createWatchConditions(proxyURL string, idleAfter int, idleLongBuild int, lo
 		time.Duration(idleAfter)*time.Minute,
 		time.Duration(idleLongBuild)*time.Hour))
 
-	// If we have access to Proxy, add User condition.
-	if len(proxyURL) > 0 {
-		log.Info("Adding 'user' condition")
-		conditions.Add("user", condition.NewUserCondition(proxyURL, time.Duration(idleAfter)*time.Minute))
-	}
-
 	return &conditions
 }


### PR DESCRIPTION
The DC condition and the build condition should keep jenkins unidled
after the build. Removing user-condition since it fails with the
following error.

```
proxy returned error: invalid character '\'' looking for beginning of object key string

```

Related to https://github.com/fabric8-services/fabric8-jenkins-idler/issues/296