### PR TITLE
Allow grace time after build is done

### DIFF
--- a/internal/condition/build_condition.go
+++ b/internal/condition/build_condition.go
@@ -100,5 +100,5 @@ func (c *BuildCondition) Eval(object interface{}) (Action, error) {
 
 	log.WithField("action", "none").Infof(
 		"%v has not yet elapsed after last done-build at %v ", c.idleAfter, completionTime)
-	return NoAction, nil
+	return UnIdle, nil
 }

--- a/internal/condition/build_condition_test.go
+++ b/internal/condition/build_condition_test.go
@@ -71,7 +71,7 @@ func Test_eval_completion_before_idletime_expires(t *testing.T) {
 	condition := NewBuildCondition(time.Duration(5)*time.Minute, time.Duration(5)*time.Minute)
 	result, err := condition.Eval(user)
 	assert.NoError(t, err)
-	assert.Equal(t, NoAction, result, "Condition should evaluate to UnIdle.")
+	assert.Equal(t, UnIdle, result, "Condition should evaluate to UnIdle.")
 }
 
 func Test_eval_completion_after_idletime_expires(t *testing.T) {


### PR DESCRIPTION
E2E tests fail due to a timing issue. Here is what happens

  1. 00:00:00: Jenkins gets reset
  2. 00:45:00: So it is scheduled to be idled at 00:45:00
  3. 00:43:00: **But** A test run starts
  4. 00:45:00: Idler tries to idle when it reaches 45mins but finds that
               there is an active build so it waits for the build to be over
  5. 00:52:00: it receives a build-complete event and then it idles jenkins
               as the time has already gone past the allocated 45m
  6. 00:52:45: test tries to look at the logs but fails as jenkins is idled.

Hence this patch fixes this condition by ensuring that Jenkins stays running
for 45m (idlerAfter duration) even after a build is complete.

Fixes: openshiftio/openshift.io#4503