### PR TITLE
Decrease required CPU

### DIFF
--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -96,10 +96,10 @@ objects:
           resources:
             requests:
               memory: "1Gi"
-              cpu: "1"
+              cpu: "40m"
             limits:
               memory: "2Gi"
-              cpu: "2"
+              cpu: "500m"
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}


### PR DESCRIPTION
The current 1 core limit is too high. I don't see the idler using CPU that much at all. Such big requirements to CPU cause deployment issues.