### PR TITLE
Move from epel-testing to epel-release

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -19,8 +19,8 @@ function setup_build_environment() {
     # We need to disable selinux for now, XXX
     /usr/sbin/setenforce 0 || :
 
-    yum install epel-release --enablerepo=extras -y
-    yum -y install --enablerepo=epel-testing docker make golang git
+    yum install epel-release -y
+    yum -y install --enablerepo=epel docker make golang git
     service docker start
 
     echo 'CICO: Build environment created.'


### PR DESCRIPTION
This patch is to use go library from epel-release
in spite of epel-testing

Fix related to https://github.com/openshiftio/openshift.io/issues/4618