### PR TITLE
Reduce verbosity level of logs

### DIFF
--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -46,7 +46,7 @@ objects:
           - name: JC_TOGGLE_API_URL
             value: "http://f8toggles/api"
           - name: JC_LOG_LEVEL
-            value: "info"
+            value: "warning"
           - name: GODEBUG
             value: "gctrace=0"
           - name: JC_AUTH_URL


### PR DESCRIPTION
Set the verbosity of the log to "warning" as idler currently is
logging more than 12million records a day.

Fixes:  https://github.com/fabric8-services/fabric8-jenkins-idler/issues/310