### PR TITLE
increases verbosity of logs

### DIFF
--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -46,7 +46,7 @@ objects:
           - name: JC_TOGGLE_API_URL
             value: "http://f8toggles/api"
           - name: JC_LOG_LEVEL
-            value: "warning"
+            value: "info"
           - name: GODEBUG
             value: "gctrace=0"
           - name: JC_AUTH_URL


### PR DESCRIPTION
Its observed that us-east2 running 1000+ jenkins after
jenkins updates. Idler logs are not enough to follow
why its failing to idle the Jenkins.

This patch changes log level from warning to info