### PR TITLE
Improves log messages

### DIFF
--- a/internal/idler/user_idler.go
+++ b/internal/idler/user_idler.go
@@ -131,7 +131,7 @@ func (idler *UserIdler) checkIdle() error {
 		idler.user.IdleStatus = model.NewIdleStatus(err)
 	} else if action == condition.UnIdle {
 		if err := idler.doUnIdle(); err != nil {
-			log.Errorf("Idling jenkins failed:  %s", err)
+			log.Errorf("UnIdling jenkins failed:  %s", err)
 			return err
 		}
 		// TODO: find a better way to update IdleStatus inside doUnIdle()

--- a/internal/openshift/controller.go
+++ b/internal/openshift/controller.go
@@ -246,6 +246,7 @@ func (c *controllerImpl) createIfNotExist(ns string) (bool, error) {
 		return false, nil
 	}
 
+	log.Infof("tenant info from tenant-service %v", ti)
 	user := model.NewUser(ti.Data[0].ID, ns)
 
 	userIdler := idler.NewUserIdler(


### PR DESCRIPTION
Idling/Unidling error message is ambigious. Also
its hard to trace what info tenant service returns to
idler

This patch improves log message which says idling or unidling
failed.
Also adds log message to debug what info tenant service returns
in response.