### PR TITLE
reduces log verbosity

### DIFF
--- a/internal/openshift/controller.go
+++ b/internal/openshift/controller.go
@@ -246,7 +246,7 @@ func (c *controllerImpl) createIfNotExist(ns string) (bool, error) {
 		return false, nil
 	}
 
-	log.Infof("tenant info from tenant-service %v", ti)
+	log.Warnf("tenant info from tenant-service %v", ti)
 	user := model.NewUser(ti.Data[0].ID, ns)
 
 	userIdler := idler.NewUserIdler(

--- a/openshift/jenkins-idler.app.yaml
+++ b/openshift/jenkins-idler.app.yaml
@@ -46,7 +46,7 @@ objects:
           - name: JC_TOGGLE_API_URL
             value: "http://f8toggles/api"
           - name: JC_LOG_LEVEL
-            value: "info"
+            value: "warning"
           - name: GODEBUG
             value: "gctrace=0"
           - name: JC_AUTH_URL


### PR DESCRIPTION
Verbosity of logs was increased to get more insights on why
us-east-2 jenkins pods are not getting idled.

After resolving an issue, now reducing the logs verbosity level
from info to warning.
Changing one log message level from info to warning.

Related to: https://github.com/fabric8-services/fabric8-jenkins-idler/issues/315