### PR TITLE
Allow the idler to exclude some deployments from idling

### DIFF
--- a/internal/model/stringset.go
+++ b/internal/model/stringset.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	cmap "github.com/orcaman/concurrent-map"
+)
+
+// StringSet is a type-safe and concurrent map keeping track of disabled v for idler.
+type StringSet struct {
+	cmap.ConcurrentMap
+}
+
+// NewStringSet creates a new instance of StringSet map.
+func NewStringSet() *StringSet {
+	return &StringSet{cmap.New()}
+}
+
+// Add stores the specified value under the key user.
+func (m *StringSet) Add(vs []string) {
+	for _, v := range vs {
+		m.ConcurrentMap.Set(v, true)
+	}
+}
+
+// Remove deletes the specified disabled user from the map.
+func (m *StringSet) Remove(vs []string) {
+	for _, v := range vs {
+		m.ConcurrentMap.Remove(v)
+	}
+}

--- a/internal/model/stringset_test.go
+++ b/internal/model/stringset_test.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringSet_new(t *testing.T) {
+	s := NewStringSet()
+	assert.NotNil(t, s, "must return a new object")
+}
+
+func TestStringSet_count(t *testing.T) {
+	s := NewStringSet()
+	assert.Equal(t, 0, s.Count(), "must have 0 items")
+}
+
+func TestStringSet_add(t *testing.T) {
+	s := NewStringSet()
+	s.Add([]string{"foo", "bar"})
+	assert.Equal(t, 2, s.Count())
+}
+
+func TestStringSet_has(t *testing.T) {
+	s := NewStringSet()
+	assert.False(t, s.Has("foo"), "must be empty")
+	s.Add([]string{"foo", "bar"})
+
+	assert.True(t, s.Has("foo"), "must be present after adding")
+	assert.True(t, s.Has("bar"), "must be present after adding")
+	assert.False(t, s.Has("foobar"), "non existent key seems to be found")
+}
+
+func TestStringSet_remove(t *testing.T) {
+	s := NewStringSet()
+	assert.Equal(t, 0, s.Count())
+
+	s.Add([]string{"foo", "bar"})
+	assert.Equal(t, 2, s.Count())
+
+	s.Remove([]string{"bar"})
+	assert.Equal(t, 1, s.Count())
+
+	assert.False(t, s.Has("bar"), "key that got removed still exists")
+}
+
+func TestStringSet_keys(t *testing.T) {
+	s := NewStringSet()
+
+	keys := []string{"foo", "bar"}
+
+	s.Add(keys)
+
+	values := s.Keys()
+	sort.Strings(keys)
+	sort.Strings(values)
+
+	assert.Equal(t, keys, values)
+}

--- a/internal/openshift/controller_test.go
+++ b/internal/openshift/controller_test.go
@@ -219,7 +219,8 @@ func setUp(t *testing.T) {
 	defer cancel()
 
 	userIdlers := NewUserIdlerMap()
-	controller = NewController(ctx, "", "", userIdlers, tenantService, features, &mock.Config{}, &wg, cancel)
+	disabledUsers := model.NewStringSet()
+	controller = NewController(ctx, "", "", userIdlers, tenantService, features, &mock.Config{}, &wg, cancel, disabledUsers)
 }
 
 func emptyChannel(ch chan model.User) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -86,9 +86,6 @@ func (r *Router) Shutdown() {
 func CreateAPIRouter(api api.IdlerAPI) *httprouter.Router {
 	router := httprouter.New()
 
-	router.GET("/api/idler/info/:namespace", api.Info)
-	router.GET("/api/idler/info/:namespace/", api.Info)
-
 	router.GET("/api/idler/idle/:namespace", api.Idle)
 	router.GET("/api/idler/idle/:namespace/", api.Idle)
 
@@ -106,6 +103,12 @@ func CreateAPIRouter(api api.IdlerAPI) *httprouter.Router {
 
 	router.POST("/api/idler/reset/:namespace", api.Reset)
 	router.POST("/api/idler/reset/:namespace/", api.Reset)
+
+	router.GET("/api/idler/userstatus", api.GetDisabledUserIdlers)
+	router.GET("/api/idler/userstatus/", api.GetDisabledUserIdlers)
+
+	router.POST("/api/idler/userstatus", api.SetUserIdlerStatus)
+	router.POST("/api/idler/userstatus/", api.SetUserIdlerStatus)
 
 	return router
 }

--- a/internal/testutils/mock/mock_idler_api.go
+++ b/internal/testutils/mock/mock_idler_api.go
@@ -4,16 +4,11 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	log "github.com/sirupsen/logrus"
 )
 
 // IdlerAPI defines the REST endpoints of the Idler
 type IdlerAPI struct {
-}
-
-// Info writes a JSON representation of internal state of the specified namespace to the response writer.
-func (i *IdlerAPI) Info(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Write([]byte("Info"))
-	w.WriteHeader(http.StatusOK)
 }
 
 // Idle triggers an idling of the Jenkins service running in the namespace specified in the namespace
@@ -56,5 +51,22 @@ func (i *IdlerAPI) Reset(w http.ResponseWriter, r *http.Request, ps httprouter.P
 // ClusterDNSView writes a JSON representation of the current cluster state to the response writer.
 func (i *IdlerAPI) ClusterDNSView(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	w.Write([]byte("GetClusterDNSView"))
+	w.WriteHeader(http.StatusOK)
+}
+
+//SetUserIdlerStatus sets the user status
+func (i *IdlerAPI) SetUserIdlerStatus(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	_, err := w.Write([]byte("SetUserIdlerStatus"))
+	if err != nil {
+		log.Error(err)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+//GetDisabledUserIdlers set the user status
+func (i *IdlerAPI) GetDisabledUserIdlers(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if _, err := w.Write([]byte("GetDisabledUserIdlers")); err != nil {
+		log.Error(err)
+	}
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Allow the idler to exclude some deployments from idling
Resolves
- https://github.com/fabric8-services/fabric8-jenkins-idler/issues/232