### PR TITLE
updates log messages for feature toggle service

### DIFF
--- a/cmd/fabric8-jenkins-idler/main.go
+++ b/cmd/fabric8-jenkins-idler/main.go
@@ -108,9 +108,10 @@ func createFeatureToggle(config configuration.Configuration) toggles.Features {
 	var err error
 	var features toggles.Features
 	if len(config.GetFixedUuids()) > 0 {
-		mainLogger.Infof("Using fixed UUID list for toggle feature: %s", config.GetFixedUuids())
+		mainLogger.Warnf("Using fixed UUID list for toggle feature: %s", config.GetFixedUuids())
 		features, err = toggles.NewFixedUUIDToggle(config.GetFixedUuids())
 	} else {
+		mainLogger.Warn("Using feature toggle through unleash client")
 		features, err = toggles.NewUnleashToggle(config.GetToggleURL())
 	}
 	if err != nil {


### PR DESCRIPTION
This patch updates the log messages to determine which feature
toggle service implementation used to enable/disable idler per user

Related https://github.com/fabric8-services/fabric8-jenkins-idler/issues/333