### PR TITLE
Fix idler choosing wrong feature toggle impl

### DIFF
--- a/internal/configuration/viper.go
+++ b/internal/configuration/viper.go
@@ -81,7 +81,7 @@ func (c *Config) setConfigDefaults() {
 	c.v.SetDefault(checkInterval, defaultCheckInterval)
 
 	c.v.SetDefault(debugMode, false)
-	c.v.SetDefault(fixedUuids, "")
+	c.v.SetDefault(fixedUuids, []string{})
 }
 
 // GetDebugMode returns `true` if development related features (as set via default, config file, or environment variable),
@@ -156,10 +156,11 @@ func (c *Config) GetCheckInterval() int {
 	return c.v.GetInt(checkInterval)
 }
 
-// GetFixedUuids returns a slice of fixed user uuids. The uuids are specified comma separated in the environment variable.
+// GetFixedUuids returns a slice of fixed user uuids.
+// The uuids are whitespace separated in the environment variable.
 // JC_FIXED_UUIDS.
 func (c *Config) GetFixedUuids() []string {
-	return strings.Split(c.v.GetString(fixedUuids), ",")
+	return c.v.GetStringSlice(fixedUuids)
 }
 
 // String returns string representation of configuration

--- a/internal/configuration/viper_test.go
+++ b/internal/configuration/viper_test.go
@@ -104,9 +104,17 @@ func TestConfig_GetCheckInterval(t *testing.T) {
 	assert.Equal(t, c.GetCheckInterval(), want, "Check Interval Mismatch")
 }
 
+func TestConfig_GetFixedUuids_None(t *testing.T) {
+	os.Setenv(fixedUuids, "")
+	c, _ := New("")
+	assert.Len(t, c.GetFixedUuids(), 0, "FixedUUids Mismatch")
+}
+
 func TestConfig_GetFixedUuids(t *testing.T) {
-	os.Setenv(fixedUuids, "uuid1,uuid2,uuid3")
-	want := []string{"uuid1", "uuid2", "uuid3"}
+	os.Setenv(fixedUuids, "uuid1 uuid2    uuid3 foo,bar   ")
+	//                          ^      ^^^         ^   ^^
+	//                whitespace      mulitple    coma  trailing
+	want := []string{"uuid1", "uuid2", "uuid3", "foo,bar"}
 	c, _ := New("")
 	assert.Equal(t, c.GetFixedUuids(), want, "FixedUUids Mismatch")
 }


### PR DESCRIPTION
Feature toggle has 2 implementations and the way it is chosen in main is
based on the value of JC_FIXED_UUID environment variable.
e.g.

```go
// main.go: createFeatureToggle

if len(config.GetFixedUuids()) > 0 {
  f, err = toggles.NewFixedUUIDToggle(config.GetFixedUuids())
} else {
  f, err = toggles.NewUnleashToggle(config.GetToggleURL())
}

```

The recent change to idler configuration package to use viper ( 73d8f0ed6864d40905cd72747a517de59adababf ) introduced
a change (regression) that resulted in GetFixedUuids returning a `[]string{ "" }` 
when the variable isn't set. 

This meant that idler would always choose the FixedUUID toggle instead of using
the actual feature toggle service.

This patch fixes the issue by fixing GetFixedUuids to return empty slice
if the env var isn't set.

Fixes #333